### PR TITLE
feat : 특일 데이터 수집 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ storybook-static/
 
 .metadata/
 /.metadata/
+backend/.metadata/.log
 
 # Maven
 target/

--- a/backend/src/main/java/com/voiz/controller/DataCollectorController.java
+++ b/backend/src/main/java/com/voiz/controller/DataCollectorController.java
@@ -1,0 +1,33 @@
+package com.voiz.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.voiz.service.CollectorService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@RestController
+@RequestMapping("/api/collect")
+@Tag(name = "Data Collect", description = "데이터 수집 API")
+public class DataCollectorController {
+	
+	@Autowired
+	private CollectorService collectorService;
+	
+	@PostMapping("/special-day")
+	@Operation(summary = "특일데이터수집", description = "한국천문연구원 특일 정보제공 서비스 API를 이용하여 특정년도의 특일 데이터를 수집하고 DB에 저장합니다.")
+	public ResponseEntity<Void> collectSpecialDay(@RequestParam String year) {
+	    boolean success = collectorService.collect(year);
+	    if (success) {
+	        return ResponseEntity.ok().build();
+	    } else {
+	        return ResponseEntity.internalServerError().build();
+	    }
+	}
+}

--- a/backend/src/main/java/com/voiz/mapper/SpecialDayRepository.java
+++ b/backend/src/main/java/com/voiz/mapper/SpecialDayRepository.java
@@ -1,0 +1,13 @@
+package com.voiz.mapper;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.voiz.vo.SpecialDay;
+
+@Repository
+public interface SpecialDayRepository extends JpaRepository<SpecialDay, Integer> {
+
+}

--- a/backend/src/main/java/com/voiz/service/CollectorService.java
+++ b/backend/src/main/java/com/voiz/service/CollectorService.java
@@ -1,0 +1,74 @@
+package com.voiz.service;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.voiz.mapper.SpecialDayRepository;
+import com.voiz.util.SpecialDayApi;
+import com.voiz.vo.SpecialDay;
+
+@Service
+public class CollectorService {
+
+	@Autowired
+	private SpecialDayRepository specialDayRepository; 
+	
+	@Autowired
+	private SpecialDayApi specialDayApi;
+	
+	public boolean collect(String year) {
+		Map<String, String> endpoints = Map.of(
+		        "공휴일", "getRestDeInfo",
+		        "국경일", "getHoliDeInfo",
+		        "절기", "get24DivisionsInfo",
+		        "기념일", "getAnniversaryInfo",
+		        "잡절", "getSundryDayInfo"
+		    );
+		
+//		List<SpecialDay> allSpecialDays = new ArrayList<>();
+		Map<String, SpecialDay> specialDayMap = new HashMap<>();
+        try {
+        	for (Map.Entry<String, String> entry : endpoints.entrySet()) {
+        		for (int i = 1; i <= 12; i++) {
+        		    String month = String.format("%02d", i); // "01", "02", ..., "12"
+        		    String type = entry.getKey();       // "공휴일"
+            	    String endpoint = entry.getValue();     // "getRestDeInfo"
+            	    List<SpecialDay> result = specialDayApi.getSpecialDay(year, month, endpoint, type);
+            	    
+            	    for (SpecialDay day : result) {
+            	    	 String key = day.getName();
+            	    	 if (specialDayMap.containsKey(key)) {
+            	                SpecialDay existing = specialDayMap.get(key);
+            	                // 종료일 갱신: 더 큰 endDate 저장
+            	                if (day.getEndDate().isAfter(existing.getEndDate())) {
+            	                    existing.setEndDate(day.getEndDate());
+            	                }
+            	                
+            	            } else {
+            	                // 처음 들어오는 데이터는 복사해서 저장
+            	                specialDayMap.put(key, day);
+            	            }
+            	    }
+//            	    allSpecialDays.addAll(result);
+        		} 		
+        	}
+        	// 최종 리스트로 변환
+        	List<SpecialDay> allSpecialDays = new ArrayList<>(specialDayMap.values());
+//			List<SpecialDay> result = specialDayApi.getSpecialDay(year, "06", "getRestDeInfo", "공휴일");
+			specialDayRepository.saveAll(allSpecialDays);
+			return true;
+		} catch (IOException e) {
+			e.printStackTrace();
+			return false;
+		}
+
+	}
+	
+}

--- a/backend/src/main/java/com/voiz/util/SpecialDayApi.java
+++ b/backend/src/main/java/com/voiz/util/SpecialDayApi.java
@@ -1,0 +1,90 @@
+package com.voiz.util;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.voiz.vo.SpecialDay;
+
+@Component
+public class SpecialDayApi {
+
+	// API 호출에 필요한 인증 키
+    public static final String SERVICE_KEY = "Jh+qx6lvBpNoI54Wk48m6uiCTbx/La68eVaDXDTQ+vuKqMqdo24ZhlznKur8ZKvowJ8nTcnlC6mLgQW9GfSHJA==";
+    
+    // Base URL
+    public static final String BASE_URL = "http://apis.data.go.kr/B090041/openapi/service/SpcdeInfoService";
+    
+    public List<SpecialDay> getSpecialDay(String year, String month, String endpoint, String type) throws IOException {
+    	
+    	List<SpecialDay> result = new ArrayList<>();
+    	
+    	StringBuilder urlBuilder = new StringBuilder(BASE_URL + "/" + endpoint); /*URL*/
+    	urlBuilder.append("?" + URLEncoder.encode("ServiceKey","UTF-8") + "=" + URLEncoder.encode(SERVICE_KEY, "UTF-8")); /*Service Key*/
+        urlBuilder.append("&" + URLEncoder.encode("numOfRows","UTF-8") + "=" + URLEncoder.encode("100", "UTF-8")); /*한 페이지 결과 수*/
+        urlBuilder.append("&" + URLEncoder.encode("solYear","UTF-8") + "=" + URLEncoder.encode(year, "UTF-8")); /*연*/
+        urlBuilder.append("&" + URLEncoder.encode("solMonth","UTF-8") + "=" + URLEncoder.encode(month, "UTF-8")); /*월*/
+        urlBuilder.append("&" + URLEncoder.encode("_type","UTF-8") + "=" + URLEncoder.encode("json", "UTF-8")); /*월*/
+        URL url = new URL(urlBuilder.toString());
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.setRequestMethod("GET");
+        conn.setRequestProperty("Content-type", "application/json");
+        System.out.println("🔍 요청 URL: " + urlBuilder.toString());
+        System.out.println("Response code: " + conn.getResponseCode());
+        BufferedReader rd;
+        if(conn.getResponseCode() >= 200 && conn.getResponseCode() <= 300) {
+            rd = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+        } else {
+            rd = new BufferedReader(new InputStreamReader(conn.getErrorStream()));
+        }
+        StringBuilder sb = new StringBuilder();
+        String line;
+        while ((line = rd.readLine()) != null) {
+            sb.append(line);
+        }
+        rd.close();
+        conn.disconnect();
+        System.out.println(sb.toString());
+        
+     // 👇 JSON 파싱 후 리스트에 add
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode root = objectMapper.readTree(sb.toString());
+        JsonNode items = root.path("response").path("body").path("items").path("item");
+        
+        if (items.isArray()) {
+            for (JsonNode item : items) {
+                SpecialDay specialDay = new SpecialDay();
+                specialDay.setName(item.path("dateName").asText());
+                specialDay.setType(type);
+                //specialDay.setCategory("기타");
+                String locdate = item.path("locdate").asText();
+                LocalDate date = LocalDate.parse(locdate, DateTimeFormatter.ofPattern("yyyyMMdd"));
+                specialDay.setStartDate(date);
+                specialDay.setEndDate(date);
+                String isHolidayStr = item.path("isHoliday").asText("N");
+                specialDay.setIsHoliday("Y".equals(isHolidayStr) ? 1 : 0);
+                result.add(specialDay);
+            }
+        }
+        
+        return result;
+
+    }
+  
+    
+    
+}

--- a/backend/src/main/java/com/voiz/vo/SpecialDay.java
+++ b/backend/src/main/java/com/voiz/vo/SpecialDay.java
@@ -1,0 +1,42 @@
+package com.voiz.vo;
+
+import java.time.LocalDate;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "VOYZ_SPECIAL_DAY")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class SpecialDay {
+
+	@Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "special_day_seq")
+    @SequenceGenerator(name = "special_day_seq", sequenceName = "SPECIAL_DAY_SEQUENCE", allocationSize = 1)
+    @Column(name = "SD_IDX")
+    private int sd_idx;
+	
+	@Column(name = "NAME", nullable = false)
+    private String name;
+	
+	@Column(name = "TYPE", nullable = false)
+	private String type;
+	
+	@Column(name = "CATEGORY")
+	private String category;
+	
+	@Column(name = "START_DATE", nullable = false)
+	private LocalDate startDate;
+
+	@Column(name = "END_DATE", nullable = false)
+	private LocalDate endDate;
+
+	@Column(name = "IS_HOLIDAY", nullable = false)
+	private int isHoliday;
+	
+	
+}


### PR DESCRIPTION
## 작업 내용
- 특일 데이터 수집 API 구현
- 한국천문연구원 특일 정보제공 서비스 API를 활용하여 데이터를 수집해서 DB에 저장
- 연도를 입력값으로 받아 해당 년도의 국경일, 공휴일, 기념일, 24절기, 잡절 정보를 수집 

## 체크리스트
- [ ] 현재 데이터가 이미 존재해도 같은 년도 재호출시 다시 쌓임
- [ ] 현재 카테고리 컬럼은 널값으로 입력

## 트러블 슈팅
- 특일이 연속으로 존재하거나(ex. 설날(01.28~01.30) type이 겹치는 경우(ex. 국경일이면서 공휴일)
   한 특일에 대해서 여러 행이 DB에 입력되는 문제 발생
   => 전처리를 통해 시작일, 끝일 컬럼으로 처리, 국경일이면서 공휴일인 경우 공휴일로 저장