### PR TITLE
feat : 특일데이터 - 사용자 매치 API 구현(테스트용 - 모델 미구현)

### DIFF
--- a/backend/src/main/java/com/voiz/controller/DataMatchController.java
+++ b/backend/src/main/java/com/voiz/controller/DataMatchController.java
@@ -1,0 +1,38 @@
+package com.voiz.controller;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.voiz.dto.MatchRequestDto;
+import com.voiz.service.MatchService;
+import com.voiz.vo.SpecialDayMatch;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@RestController
+@RequestMapping("/api/match")
+@Tag(name = "Data Match", description = "사용자-데이터 매칭 API")
+public class DataMatchController {
+
+	@Autowired
+	private MatchService matchService;
+	
+	@PostMapping("/special-day")
+	@Operation(summary = "특일데이터 매칭", description = "특일 데이터와 사용자의 업종 카테고리를 고려해서 연관성이 높을 시 매칭시켜 DB에 저장합니다.")
+	public ResponseEntity<String> matchSpecialDay(@RequestBody MatchRequestDto matchRequest){
+		List<SpecialDayMatch> result = matchService.match(matchRequest);
+		boolean success = matchService.insert(result);
+	    if (success) {
+	        return ResponseEntity.ok().build();
+	    } else {
+	        return ResponseEntity.internalServerError().build();
+	    }
+	}
+}

--- a/backend/src/main/java/com/voiz/dto/MatchRequestDto.java
+++ b/backend/src/main/java/com/voiz/dto/MatchRequestDto.java
@@ -1,0 +1,14 @@
+package com.voiz.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class MatchRequestDto {
+	private String userId;
+	private String storeCategory;
+	private String storeAddress;
+}

--- a/backend/src/main/java/com/voiz/dto/MatchSpecialDayDto.java
+++ b/backend/src/main/java/com/voiz/dto/MatchSpecialDayDto.java
@@ -1,0 +1,14 @@
+package com.voiz.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class MatchSpecialDayDto {
+	private int sd_idx;
+	private String name;
+	private String category;
+}

--- a/backend/src/main/java/com/voiz/mapper/SpecialDayMatchRepository.java
+++ b/backend/src/main/java/com/voiz/mapper/SpecialDayMatchRepository.java
@@ -1,0 +1,11 @@
+package com.voiz.mapper;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.voiz.vo.SpecialDayMatch;
+
+@Repository
+public interface SpecialDayMatchRepository extends JpaRepository<SpecialDayMatch, Integer> {
+
+}

--- a/backend/src/main/java/com/voiz/mapper/SpecialDayRepository.java
+++ b/backend/src/main/java/com/voiz/mapper/SpecialDayRepository.java
@@ -1,13 +1,18 @@
 package com.voiz.mapper;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import com.voiz.dto.MatchSpecialDayDto;
 import com.voiz.vo.SpecialDay;
 
 @Repository
 public interface SpecialDayRepository extends JpaRepository<SpecialDay, Integer> {
-
+	
+	@Query("SELECT new com.voiz.dto.MatchSpecialDayDto(s.sd_idx, s.name, s.category) FROM SpecialDay s")
+	List<MatchSpecialDayDto> findForMatch();
 }

--- a/backend/src/main/java/com/voiz/mapper/UsersRepository.java
+++ b/backend/src/main/java/com/voiz/mapper/UsersRepository.java
@@ -1,0 +1,11 @@
+package com.voiz.mapper;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.voiz.vo.Users;
+
+@Repository
+public interface UsersRepository extends JpaRepository<Users, String>{
+
+}

--- a/backend/src/main/java/com/voiz/service/FastApiClient.java
+++ b/backend/src/main/java/com/voiz/service/FastApiClient.java
@@ -66,4 +66,9 @@ public class FastApiClient {
         String endpoint = "/api/predict/" + modelName;
         return postDataToFastApi(endpoint, inputData);
     }
+    
+    public ResponseEntity<String> getMatchResult(String modelName, Map<String, Object> inputData){
+    	String endpoint = "/api/match/" + modelName;
+        return postDataToFastApi(endpoint, inputData);
+    }
 } 

--- a/backend/src/main/java/com/voiz/service/MatchService.java
+++ b/backend/src/main/java/com/voiz/service/MatchService.java
@@ -1,0 +1,61 @@
+package com.voiz.service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.voiz.dto.MatchRequestDto;
+import com.voiz.dto.MatchSpecialDayDto;
+import com.voiz.mapper.SpecialDayMatchRepository;
+import com.voiz.mapper.SpecialDayRepository;
+import com.voiz.mapper.UsersRepository;
+import com.voiz.vo.SpecialDayMatch;
+
+@Service
+public class MatchService {
+	
+	@Autowired
+    private FastApiClient fastApiClient;
+	
+	@Autowired
+	private SpecialDayRepository specialDayRepository;
+	
+	@Autowired
+	private SpecialDayMatchRepository specialDayMatchRepository;
+	
+	public List<SpecialDayMatch> match(MatchRequestDto matchRequest) {
+		List<MatchSpecialDayDto> specialDays = specialDayRepository.findForMatch();
+		
+		// Map으로 직접 구성
+	    Map<String, Object> body = new HashMap<>();
+	    body.put("matchRequest", matchRequest);
+	    body.put("specialDays", specialDays);
+	    try {
+	    	ResponseEntity<String> response = fastApiClient.getMatchResult("specialDay", body);
+	    	String responseBody = response.getBody();
+	    	
+	    	ObjectMapper objectMapper = new ObjectMapper();
+	    	List<SpecialDayMatch> matches = objectMapper.readValue(responseBody, new TypeReference<List<SpecialDayMatch>>() {});
+	    	
+	    	return matches;
+	    } catch (Exception e) {
+	    	return null;
+	    }
+	}
+	
+	public boolean insert(List<SpecialDayMatch> specialDayMatch) {
+		try {
+	        specialDayMatchRepository.saveAll(specialDayMatch);
+	        return true;
+	    } catch (Exception e) {
+	        e.printStackTrace();
+	        return false;
+	    }
+	}
+}

--- a/backend/src/main/java/com/voiz/vo/SpecialDayMatch.java
+++ b/backend/src/main/java/com/voiz/vo/SpecialDayMatch.java
@@ -1,0 +1,28 @@
+package com.voiz.vo;
+
+import java.time.LocalDate;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "VOYZ_SPECIAL_DAY_MATCH")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class SpecialDayMatch {
+	
+	@Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "special_day_match_seq")
+    @SequenceGenerator(name = "special_day_match_seq", sequenceName = "SPECIAL_DAY_MATCH_SEQUENCE", allocationSize = 1)
+    @Column(name = "SM_IDX")
+    private int sm_idx;
+	
+	@Column(name = "SD_IDX", nullable = false)
+	private int sd_idx;
+	
+	@Column(name = "USER_ID", nullable = false)
+	private String userId;
+}

--- a/backend/src/main/java/com/voiz/vo/Users.java
+++ b/backend/src/main/java/com/voiz/vo/Users.java
@@ -1,0 +1,53 @@
+package com.voiz.vo;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "VOYZ_USERS")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Users {
+	
+	@Id
+	@Column(name = "USER_ID")
+	private String userId;
+	
+	@Column(name = "USER_PW", nullable = false)
+	private String userPw;
+	
+	@Column(name = "USER_NAME", nullable = false)
+	private String userName;
+	
+	@Column(name = "USER_EMAIL", nullable = false)
+	private String userEmail;
+	
+	@Column(name = "USER_PHONE", nullable = false)
+	private String userPhone;
+	
+	@Column(name = "STORE_NAME", nullable = false)
+	private String storeName;
+	
+	@Column(name = "STORE_CATEGORY", nullable = false)
+	private String storeCategory;
+	
+	@Column(name = "STORE_ADDRESS", nullable = false)
+	private String storeAddress;
+	
+	@Column(name = "ROLE", nullable = false)
+	private String role;
+	
+	@Column(name = "CREATED_AT")
+	private LocalDateTime createdAt;
+	
+	@PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+    }
+	
+}

--- a/ml/config.py
+++ b/ml/config.py
@@ -3,7 +3,7 @@ FastAPI 설정 파일
 """
 
 from pydantic import BaseModel
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
 
 # API 설정
 API_CONFIG = {
@@ -45,3 +45,23 @@ SAMPLE_DATA = {
     "categories": ["전자제품", "의류", "식품", "가구"],
     "category_sales": [45, 30, 15, 10]
 } 
+
+# 고객 - 데이터 매칭 데이터 모델 정의
+class MatchRequestDto(BaseModel):
+    userId: str
+    storeCategory: str
+    storeAddress: str
+
+class MatchSpecialDayDto(BaseModel):
+    sd_idx: int
+    name: str
+    category: Optional[str] = None
+
+class SpecialDayMatchRequest(BaseModel):
+    matchRequest: MatchRequestDto
+    specialDays: List[MatchSpecialDayDto]
+
+class SpecialDayMatch(BaseModel):
+    sm_idx: int
+    sd_idx: int
+    userId: str

--- a/ml/main.py
+++ b/ml/main.py
@@ -8,10 +8,11 @@ from typing import Dict, Any, List
 from datetime import datetime
 
 # 설정 및 모델 import
-from config import API_CONFIG, SAMPLE_DATA, PredictionRequest, AnalysisRequest
+from config import API_CONFIG, SAMPLE_DATA, PredictionRequest, AnalysisRequest, SpecialDayMatchRequest
 from models.prediction_models import PredictionModels
 from models.analysis_models import AnalysisModels
 from services.dashboard_service import DashboardService
+from models.match_models import MatchModels
 
 # FastAPI 앱 생성
 app = FastAPI(
@@ -141,6 +142,23 @@ def customer_segmentation(request: Dict[str, Any]):
 def get_dashboard_data():
     """대시보드용 실시간 데이터"""
     return DashboardService.get_dashboard_data()
+
+# 특일 - 고객 매칭
+@app.post("/api/match/specialDay")
+def specialDay_match(request: SpecialDayMatchRequest):
+    """ 특일 - 고객 데이터 매칭"""
+    result = []
+    for i, day in enumerate(request.specialDays):
+        # llama 모델로 판단
+        judgement = MatchModels.specialDay_model(day.name, request.matchRequest.storeCategory)
+
+        if judgement == 1:
+            result.append({
+                 "sd_idx": day.sd_idx,
+                 "userId": request.matchRequest.userId
+            })
+
+    return result
 
 if __name__ == "__main__":
     import uvicorn

--- a/ml/models/match_models.py
+++ b/ml/models/match_models.py
@@ -1,0 +1,18 @@
+"""
+매칭 모델 모듈
+"""
+
+import numpy as np
+from typing import Dict, Any, List
+
+class MatchModels:
+    """매칭 모델 클래스"""
+    
+    @staticmethod
+    def specialDay_model(event: str, store_type: str) -> int:
+        """매칭 모델"""
+        keywords = ["초복", "중복", "말복"]
+        if any(bok in event for bok in keywords) and "치킨집" in store_type:
+            return 1
+        return 0
+        


### PR DESCRIPTION
## 작업 내용
- 특일 데이터 - 사용자 매치 API 구현
- 데이터베이스 내 특일데이터와 사용자 정보를 매칭하여 마케팅 제안이 적절한 매칭 결과를 DB에 저장
- 사용자 ID, 업종명, 가게위치를 DTO로 받아 모든 특일데이터(ID, 이름, 카테고리 활용)와 매칭(fastApi에서 진행)
- 매칭 결과를 DB에 입력

## 체크리스트
- [ ] 현재 데이터가 이미 존재해도 재호출시 다시 쌓임
- [ ] 현재 특일 데이터의 카테고리 컬럼은 모두 널값
- [ ] 추후 모델 추가해야함
       현재는 업종이 "치킨집"일 경우 "초복", "중복", "말복"과 매칭되도록 테스트용으로 구현

## 트러블 슈팅
- LLM 모델 매칭에 활용 자체는 가능, 다만 비용 문제로 구현 실패
  : You have exceeded your monthly included credits for Inference Providers. 
    Subscribe to PRO to get 20x more monthly included credits.
- 테스트 모델은 meta-llama/Meta-Llama-3-8B-Instruct(허깅페이스)

## 스크린샷
- LLM 모델 활용 예시
<img width="1452" height="295" alt="image" src="https://github.com/user-attachments/assets/e3d99d3e-04c0-4a83-9507-3e7cdcbd9600" />
<img width="453" height="155" alt="스크린샷 2025-07-26 162506" src="https://github.com/user-attachments/assets/4bac8a0a-f223-400b-bb6c-d714d05609bb" />
