### PR TITLE
feat : 리마인더 일정 상세조회 API 구현

### DIFF
--- a/backend/src/main/java/com/voiz/controller/CalendarController.java
+++ b/backend/src/main/java/com/voiz/controller/CalendarController.java
@@ -1,0 +1,36 @@
+package com.voiz.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.voiz.service.CalendarService;
+import com.voiz.vo.Marketing;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@RestController
+@RequestMapping("/api/calendars")
+@Tag(name = "calendar-controller", description = "일정관리 API")
+public class CalendarController {
+	
+	@Autowired
+	private CalendarService calendarService;
+	
+	@GetMapping("/reminder/{marketing_idx}")
+	@Operation(summary = "리마인더 일정 상세보기", description = "사용자가 특정 리마인더를 클릭했을 때 해당 일정 상세보기를 제공하기 위함입니다.")
+	public ResponseEntity<Marketing> getReminderByMarketingIdx(@PathVariable int marketing_idx) {
+	    Marketing reminder = calendarService.getMarketing(marketing_idx);
+	    
+	    if (reminder != null) {
+	        return ResponseEntity.ok(reminder);
+	    } else {
+	        return ResponseEntity.notFound().build(); 
+	    }
+	}
+	
+}

--- a/backend/src/main/java/com/voiz/mapper/MarketingRepository.java
+++ b/backend/src/main/java/com/voiz/mapper/MarketingRepository.java
@@ -1,0 +1,13 @@
+package com.voiz.mapper;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.voiz.vo.Marketing;
+
+@Repository
+public interface MarketingRepository extends JpaRepository<Marketing, Integer> {
+	Optional<Marketing> findByMarketingIdx(int marketingIdx);
+}

--- a/backend/src/main/java/com/voiz/service/CalendarService.java
+++ b/backend/src/main/java/com/voiz/service/CalendarService.java
@@ -1,0 +1,26 @@
+package com.voiz.service;
+
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.voiz.mapper.MarketingRepository;
+import com.voiz.vo.Marketing;
+
+@Service
+public class CalendarService {
+
+	@Autowired
+	private MarketingRepository marketingRepository;
+	
+	public Marketing getMarketing(int marketingIdx) {
+		Optional<Marketing> marketing = marketingRepository.findByMarketingIdx(marketingIdx);
+		if(marketing.isPresent()) {
+			return marketing.get();
+		}else {
+			return null;
+		}
+	}
+
+}

--- a/backend/src/main/java/com/voiz/vo/Marketing.java
+++ b/backend/src/main/java/com/voiz/vo/Marketing.java
@@ -1,0 +1,52 @@
+package com.voiz.vo;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "VOYZ_MARKETING")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Marketing {
+	
+	@Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "marketing_seq")
+    @SequenceGenerator(name = "marketing_seq", sequenceName = "MARKETING_SEQUENCE", allocationSize = 1)
+    @Column(name = "MARKETING_IDX")
+    private int marketingIdx;
+	
+	@Column(name = "TITLE", nullable = false)
+    private String title;
+	
+	@Column(name = "TYPE", nullable = false)
+    private String type;
+	
+	@Column(name = "CONTENT", nullable = false)
+    private String content;
+	
+	@Column(name = "START_DATE", nullable = false)
+	private LocalDate startDate;
+	
+	@Column(name = "END_DATE", nullable = false)
+	private LocalDate endDate;
+	
+	@Column(name = "FIXED_AT", nullable = false)
+    private LocalDateTime fixedAt;
+	
+	@Column(name = "STATUS", nullable = false)
+    private String status;
+	
+	@Column(name = "REMINDER_IDX", nullable = false)
+    private int reminder_idx;
+	
+	@PrePersist
+    protected void onCreate() {
+		fixedAt = LocalDateTime.now();
+    }
+}


### PR DESCRIPTION
## 작업 내용
- 리마인더 상세조회 API 구현
- marketing_idx를 입력받아 Marketing 테이블에서 해당 데이터 얻음

## 체크리스트
- [ ] 현재 marketing_idx가 1001인 가데이터만 존재