### PR TITLE
feat: 리마인더(마케팅 일정) 조회 API 구현

### DIFF
--- a/backend/src/main/java/com/voiz/controller/CalendarController.java
+++ b/backend/src/main/java/com/voiz/controller/CalendarController.java
@@ -1,5 +1,7 @@
 package com.voiz.controller;
 
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -42,6 +44,17 @@ public class CalendarController {
 	public ResponseEntity<Void> createReminder(@RequestBody ReminderDto reminderDto, @RequestParam String userId) {
 	    calendarService.createReminder(reminderDto, userId);
 	    return ResponseEntity.ok().build(); 
+	}
+	
+	@GetMapping("/reminder")
+	@Operation(summary = "리마인더 일정 조회", description = "사용자의 리마인더 ID를 기반으로 마케팅 일정을 월 기준으로 조회합니다. (전월~다음월까지)")
+	public ResponseEntity<List<Marketing>> getRemindersByUserAndMonth(
+	        @RequestParam("user_id") String userId,
+	        @RequestParam int year,
+	        @RequestParam int month) {
+
+	    List<Marketing> marketingList = calendarService.getMarketingListByUserAndMonth(userId, year, month);
+	    return ResponseEntity.ok(marketingList);
 	}
 	
 	

--- a/backend/src/main/java/com/voiz/mapper/MarketingRepository.java
+++ b/backend/src/main/java/com/voiz/mapper/MarketingRepository.java
@@ -1,8 +1,12 @@
 package com.voiz.mapper;
 
+import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.voiz.vo.Marketing;
@@ -10,4 +14,9 @@ import com.voiz.vo.Marketing;
 @Repository
 public interface MarketingRepository extends JpaRepository<Marketing, Integer> {
 	Optional<Marketing> findByMarketingIdx(int marketingIdx);
+
+	@Query("SELECT m FROM Marketing m WHERE m.reminder_idx = :reminderIdx AND m.startDate BETWEEN :from AND :to")
+	List<Marketing> findByReminderIdxAndDateRange(@Param("reminderIdx") int reminderIdx,
+	                                              @Param("from") LocalDate from,
+	                                              @Param("to") LocalDate to);
 }

--- a/backend/src/main/java/com/voiz/service/CalendarService.java
+++ b/backend/src/main/java/com/voiz/service/CalendarService.java
@@ -1,5 +1,8 @@
 package com.voiz.service;
 
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -39,5 +42,16 @@ public class CalendarService {
 		marketing.setStatus("진행전");
 		marketing.setType("1");
 		marketingRepository.save(marketing);
+	}
+
+	public List<Marketing> getMarketingListByUserAndMonth(String userId, int year, int month) {
+		int reminderIdx = reminderRepository.findReminderIdxByUserId(userId);
+		
+		// 해당 월 기준 전월 ~ 다음월 범위 계산
+	    YearMonth ym = YearMonth.of(year, month);
+	    LocalDate from = ym.minusMonths(1).atDay(1);          // 전월 1일
+	    LocalDate to = ym.plusMonths(1).atEndOfMonth();       // 다음월 말일
+
+	    return marketingRepository.findByReminderIdxAndDateRange(reminderIdx, from, to);
 	}
 }


### PR DESCRIPTION
## 작업 내용
- 리마인더 조회 API 구현
- userId, year, month 입력받아 입력받은 달 기준으로 전 월, 현재 월, 다음 월 리마인더 데이터 반환

## 체크리스트
- [ ] userId : test, year : 2025, month : 7로 테스트 가능

