### PR TITLE
feat: 리마인더 하단 화면 리스트 구현

### DIFF
--- a/frontend/app/src/main/java/com/voyz/presentation/component/reminder/ReminderCalendarComponent.kt
+++ b/frontend/app/src/main/java/com/voyz/presentation/component/reminder/ReminderCalendarComponent.kt
@@ -15,12 +15,17 @@ import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -149,7 +154,7 @@ private fun DaysOfWeekHeader() {
 private fun SimpleCalendarGrid(
     dates: List<ReminderCalendarDate>,
     selectedDate: LocalDate?,
-    events: Map<LocalDate, List<CalendarEvent>>,
+    events: Map<LocalDate, List<ReminderCalendarEvent>>,
     onDateClick: (LocalDate) -> Unit
 ) {
     Column(modifier = Modifier.fillMaxWidth()) {
@@ -185,12 +190,12 @@ private fun CalendarDayCell(
     date: LocalDate,
     isCurrentMonth: Boolean,
     isSelected: Boolean,
-    events: List<CalendarEvent>,
+    events: List<ReminderCalendarEvent>,
     onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val textColor = if (!isCurrentMonth) androidx.compose.ui.graphics.Color(0xFFBDBDBD) else androidx.compose.ui.graphics.Color(0xFF333333)
-
+    val textColor = if (!isCurrentMonth) Color(0xFFBDBDBD) else Color(0xFF333333)
+    val isCheckedExist = events.any { it.isChecked }
     Column(
         modifier = modifier
             .clickable(enabled = isCurrentMonth) { onClick() }
@@ -202,12 +207,12 @@ private fun CalendarDayCell(
             text = date.dayOfMonth.toString(),
             color = textColor,
             style = MaterialTheme.typography.labelSmall,
-            fontWeight = androidx.compose.ui.text.font.FontWeight.Normal,
+            fontWeight = FontWeight.Normal,
             modifier = Modifier
                 .padding(2.dp)
                 .then(
                     if (isSelected) Modifier
-                        .background(androidx.compose.ui.graphics.Color(0xFF64B5F6), CircleShape)
+                        .background(Color(0xFF64B5F6), CircleShape)
                         .padding(4.dp)
                     else Modifier.padding(4.dp)
                 )
@@ -223,22 +228,30 @@ private fun CalendarDayCell(
             modifier = Modifier.padding(top = 2.dp)
         ) {
             dotsToShow.forEach { event ->
-                Box(
-                    modifier = Modifier
-                        .size(6.dp)
-                        .background(
-                            color = when (event.id) {
-                                "1" -> androidx.compose.ui.graphics.Color(0xFFFFE0B2)
-                                "2" -> androidx.compose.ui.graphics.Color(0xFFF8BBD9)
-                                "3" -> androidx.compose.ui.graphics.Color(0xFFE8F5E8)
-                                "4" -> androidx.compose.ui.graphics.Color(0xFFE3F2FD)
-                                else -> androidx.compose.ui.graphics.Color(0xFFF3E5F5)
-                            },
-                            shape = CircleShape
-                        )
-                )
+                if (event.isChecked) {
+                    Icon(
+                        imageVector = Icons.Default.Check,
+                        contentDescription = "Checked",
+                        tint = Color(0xFF4CAF50), // 체크 색상
+                        modifier = Modifier.size(10.dp)
+                    )
+                } else {
+                    Box(
+                        modifier = Modifier
+                            .size(6.dp)
+                            .background(
+                                color = when (event.id) {
+                                    "1" -> Color(0xFFFFE0B2)
+                                    "2" -> Color(0xFFF8BBD9)
+                                    "3" -> Color(0xFFE8F5E8)
+                                    "4" -> Color(0xFFE3F2FD)
+                                    else -> Color(0xFFF3E5F5)
+                                },
+                                shape = CircleShape
+                            )
+                    )
+                }
             }
-
             if (extraCount > 0) {
                 Text(
                     text = "+$extraCount",

--- a/frontend/app/src/main/java/com/voyz/presentation/component/reminder/ReminderCalendarViewModel.kt
+++ b/frontend/app/src/main/java/com/voyz/presentation/component/reminder/ReminderCalendarViewModel.kt
@@ -7,22 +7,27 @@ import androidx.lifecycle.ViewModel
 import java.time.LocalDate
 import java.time.YearMonth
 
+
 class ReminderCalendarViewModel : ViewModel() {
-    
-    var selectedDate by mutableStateOf<LocalDate?>(null)
-        private set
-    
+
+    var selectedDate by mutableStateOf(LocalDate.now())
+
     var currentMonth by mutableStateOf(YearMonth.now())
         private set
-        
-    var events by mutableStateOf<Map<LocalDate, List<CalendarEvent>>>(
+
+    var events by mutableStateOf<Map<LocalDate, List<ReminderCalendarEvent>>>(
         // 테스트용 이벤트 데이터
         mapOf(
-            LocalDate.now().withDayOfMonth(5) to listOf(CalendarEvent("1", "회의"), CalendarEvent("2", "회의"), CalendarEvent("3", "회의"), CalendarEvent("4", "회의")),
-            LocalDate.now().withDayOfMonth(7) to listOf(CalendarEvent("5", "약속")),
-            LocalDate.now().withDayOfMonth(14) to listOf(CalendarEvent("6", "생일")),
-            LocalDate.now().withDayOfMonth(21) to listOf(CalendarEvent("7", "병원")),
-            LocalDate.now().withDayOfMonth(26) to listOf(CalendarEvent("8", "여행"))
+            LocalDate.now().withDayOfMonth(5) to listOf(
+                ReminderCalendarEvent("1", "회의"),
+                ReminderCalendarEvent("2", "회의1"),
+                ReminderCalendarEvent("3", "회의2"),
+                ReminderCalendarEvent("4", "회의3")
+            ),
+            LocalDate.now().withDayOfMonth(7) to listOf(ReminderCalendarEvent("5", "약속")),
+            LocalDate.now().withDayOfMonth(14) to listOf(ReminderCalendarEvent("6", "생일")),
+            LocalDate.now().withDayOfMonth(21) to listOf(ReminderCalendarEvent("7", "병원")),
+            LocalDate.now().withDayOfMonth(26) to listOf(ReminderCalendarEvent("8", "여행"))
         )
     )
         private set
@@ -30,55 +35,67 @@ class ReminderCalendarViewModel : ViewModel() {
     fun selectDate(date: LocalDate) {
         selectedDate = date
     }
-    
+
     fun clearSelection() {
         selectedDate = null
     }
-    
+
     fun goToNextMonth() {
         currentMonth = currentMonth.plusMonths(1)
     }
-    
+
     fun goToPreviousMonth() {
         currentMonth = currentMonth.minusMonths(1)
     }
-    
+
     fun goToNextMonthWithDirection(): Pair<YearMonth, Boolean> {
         val newMonth = currentMonth.plusMonths(1)
         currentMonth = newMonth
         return newMonth to true // true = 다음 달로 이동
     }
-    
+
     fun goToPreviousMonthWithDirection(): Pair<YearMonth, Boolean> {
         val newMonth = currentMonth.minusMonths(1)
         currentMonth = newMonth
         return newMonth to false // false = 이전 달로 이동
     }
-    
+
     fun goToMonth(yearMonth: YearMonth) {
         currentMonth = yearMonth
     }
-    
-    fun addEvent(date: LocalDate, event: CalendarEvent) {
+
+    fun addEvent(date: LocalDate, event: ReminderCalendarEvent) {
         val currentEvents = events[date] ?: emptyList()
         events = events.toMutableMap().apply {
             put(date, currentEvents + event)
         }
     }
-    
-    fun getEventsForDate(date: LocalDate): List<CalendarEvent> {
+
+    fun getEventsForDate(date: LocalDate): List<ReminderCalendarEvent> {
         return events[date] ?: emptyList()
     }
+
     fun goToToday() {
         val today = LocalDate.now()
         selectedDate = today
         currentMonth = YearMonth.from(today)
     }
-}
 
-data class CalendarEvent(
+    fun updateEventCheckStatus(event: ReminderCalendarEvent, isChecked: Boolean) {
+        val date = events.entries.find { it.value.contains(event) }?.key ?: return
+        val updatedEvents = events[date]?.map {
+            if (it.id == event.id) it.copy(isChecked = isChecked) else it
+        } ?: return
+
+        events = events.toMutableMap().apply {
+            put(date, updatedEvents)
+        }
+    }
+}
+data class ReminderCalendarEvent(
     val id: String,
     val title: String,
     val description: String? = null,
-    val time: String? = null
+    val time: String? = null,
+    var isChecked: Boolean = false
 )

--- a/frontend/app/src/main/java/com/voyz/presentation/component/reminder/ReminderDayInfoBox.kt
+++ b/frontend/app/src/main/java/com/voyz/presentation/component/reminder/ReminderDayInfoBox.kt
@@ -1,0 +1,75 @@
+package com.voyz.presentation.component.reminder
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import java.time.LocalDate
+import java.time.format.TextStyle
+import java.util.*
+
+@Composable
+fun ReminderDayInfoBox(
+    selectedDate: LocalDate,
+    weatherIcon: String,
+    temperature: String,
+    events: List<ReminderCalendarEvent>
+) {
+    val day = selectedDate.dayOfMonth         // 숫자 날짜
+    val dayOfWeek =
+        selectedDate.dayOfWeek.getDisplayName(TextStyle.FULL, Locale.KOREAN)  // "월요일" 형식
+
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = 20.dp, top = 8.dp, bottom = 8.dp),
+            horizontalAlignment = Alignment.Start,
+            verticalArrangement = Arrangement.spacedBy(4.dp)
+        ) {
+            Row(
+                verticalAlignment = Alignment.Bottom,
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                // ⬆ 날짜 숫자 (예: 28)
+                Text(
+                    text = "${selectedDate.dayOfMonth}",
+                    fontSize = 28.sp,
+                    fontWeight = FontWeight.Bold
+                )
+
+                // ⬇ 요일 (예: 월요일)
+                val dayOfWeek = selectedDate.dayOfWeek.getDisplayName(TextStyle.FULL, Locale.KOREAN)
+                Text(
+                    text = dayOfWeek,
+                    fontSize = 16.sp,
+                    color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f)
+                )
+            }
+
+            // ⛅ 날씨 & 온도
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Text(
+                    text = weatherIcon,
+                    fontSize = 20.sp
+                )
+                Text(
+                    text = temperature,
+                    fontSize = 16.sp
+                )
+            }
+        }
+    }
+}

--- a/frontend/app/src/main/java/com/voyz/presentation/component/reminder/ReminderListBox.kt
+++ b/frontend/app/src/main/java/com/voyz/presentation/component/reminder/ReminderListBox.kt
@@ -1,37 +1,176 @@
 package com.voyz.presentation.component.reminder
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.CheckboxDefaults
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.voyz.ui.theme.Blue500
+import com.voyz.ui.theme.Gray900
+import java.time.LocalDate
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.voyz.presentation.component.reminder.ReminderCalendarEvent
+
 
 @Composable
-fun ReminderListBox(events: List<CalendarEvent>) {
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 12.dp),
-        verticalArrangement = Arrangement.spacedBy(8.dp),
-        horizontalAlignment = Alignment.Start
-    ) {
-        if (events.isEmpty()) {
+fun ReminderListBox(
+    events: List<ReminderCalendarEvent>,
+    selectedDate: LocalDate,
+    viewModel: ReminderCalendarViewModel = viewModel(),
+    onEventCheckChange: (ReminderCalendarEvent, Boolean) -> Unit
+) {
+    if (events.isEmpty()) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(bottom = 60.dp),
+            contentAlignment = Alignment.Center
+        ) {
             Text(
                 text = "해당 날짜에 리마인더가 없습니다.",
                 fontSize = 16.sp,
                 color = MaterialTheme.colorScheme.onSurface
             )
-        } else {
-            events.forEach { event ->
-                Text(
-                    text = "• ${event.title}",
-                    fontSize = 16.sp,
-                    color = MaterialTheme.colorScheme.onSurface
+        }
+    } else {
+
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 8.dp, vertical = 12.dp),
+            verticalArrangement = Arrangement.spacedBy(0.dp),
+            horizontalAlignment = Alignment.Start
+        ) {
+            val sortedEvents = events.sortedWith(
+                compareBy<ReminderCalendarEvent> { it.isChecked }.thenBy { it.id }
+            )
+
+            sortedEvents.forEachIndexed { index, event ->
+                ReminderItemCard(
+                    title = event.title,
+                    isChecked = event.isChecked,
+                    onCheckChange = { checked ->
+                        viewModel.updateEventCheckStatus(event, checked)
+                        onEventCheckChange(event, checked)
+                    }
                 )
             }
         }
     }
 }
+        @Composable
+        fun ReminderItemCard(
+            title: String,
+            isChecked: Boolean,
+            onCheckChange: (Boolean) -> Unit,
+            allDay: Boolean = false
+        ) {
+            val backgroundColor = Color(0xFFBBDEFB)
+            val textColor = if (isChecked) Color(0xFF757575) else Gray900
+
+
+            Card(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 4.dp),
+                shape = RoundedCornerShape(12.dp),
+                colors = CardDefaults.cardColors(
+                    containerColor = backgroundColor
+                )
+
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 16.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    CircleCheckbox(
+                        checked = isChecked,
+                        onCheckChange = onCheckChange,
+                        modifier = Modifier
+                            .size(22.dp)
+                            .align(Alignment.Top) // 텍스트 기준으로 정렬 (중앙 아님)
+                    )
+
+                    Spacer(modifier = Modifier.width(16.dp))
+
+                    Column(
+                        verticalArrangement = Arrangement.spacedBy(2.dp)
+                    ) {
+                        Text(
+                            text = title,
+                            fontSize = 18.sp,
+                            color = textColor,
+                            fontWeight = FontWeight.Bold,
+                            textDecoration = if (isChecked) TextDecoration.LineThrough else TextDecoration.None
+                        )
+                        Text(
+                            text = "하루종일",
+                            fontSize = 13.sp,
+                            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
+                            textDecoration = if (isChecked) TextDecoration.LineThrough else TextDecoration.None
+                        )
+                    }
+                }
+            }
+        }
+        @Composable
+        fun CircleCheckbox(
+            checked: Boolean,
+            onCheckChange: (Boolean) -> Unit,
+            modifier: Modifier = Modifier,
+            checkedColor: Color = Blue500,
+            uncheckedColor: Color = Blue500,
+            size: Dp = 20.dp
+        ) {
+            Box(
+                modifier = modifier
+                    .size(size)
+                    .clickable { onCheckChange(!checked) },
+                contentAlignment = Alignment.Center
+            ) {
+                if (checked) {
+                    Icon(
+                        imageVector = Icons.Default.Check,
+                        contentDescription = "Checked",
+                        tint = checkedColor,
+                        modifier = Modifier.size(size * 1f)
+                    )
+                } else {
+                    Box(
+                        modifier = Modifier
+                            .size(size)
+                            .clip(CircleShape)
+                            .border(
+                                width = 1.5.dp,
+                                color = uncheckedColor,
+                                shape = CircleShape
+                            )
+                    )
+                }
+            }
+        }
+


### PR DESCRIPTION
리마인더 하단 일정 시각화
- 선택한 날짜에 해당하는 리마인더 목록 시각화
- 완료된 리마인더는 하단에 정렬되도록 구현
- 체크박스 스타일 적용 및 클릭 시 상태 변경 가능
- 리마인더가 없을 경우 안내 문구 출력

+버튼으로 일정추가 기능 구현