### PR TITLE
feat : 리마인더 상세페이지 이동, 스와이핑시 달력 월 자동 변경 처리

### DIFF
--- a/frontend/app/src/main/java/com/voyz/presentation/component/reminder/ReminderCalendarComponent.kt
+++ b/frontend/app/src/main/java/com/voyz/presentation/component/reminder/ReminderCalendarComponent.kt
@@ -32,6 +32,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.YearMonth
+import java.time.temporal.TemporalAdjusters
 
 @Composable
 fun ReminderCalendarComponent(
@@ -265,7 +266,7 @@ private fun CalendarDayCell(
 
 fun getDatesOfWeek(selectedDate: LocalDate?): List<ReminderCalendarDate> {
     val referenceDate = selectedDate ?: LocalDate.now()
-    val startOfWeek = referenceDate.with(DayOfWeek.MONDAY)
+    val startOfWeek = referenceDate.with(TemporalAdjusters.previousOrSame(DayOfWeek.SUNDAY))
     return (0..6).map {
         val date = startOfWeek.plusDays(it.toLong())
         ReminderCalendarDate(date, true)
@@ -276,7 +277,7 @@ fun getDatesOfMonth(yearMonth: YearMonth): List<ReminderCalendarDate> {
     val firstOfMonth = yearMonth.atDay(1)
     val firstDayOfWeek = firstOfMonth.dayOfWeek.value % 7
     val startDate = firstOfMonth.minusDays(firstDayOfWeek.toLong())
-    val totalDays = 35
+    val totalDays = 42
     return (0 until totalDays).map { offset ->
         val date = startDate.plusDays(offset.toLong())
         ReminderCalendarDate(date = date, isCurrentMonth = date.month == yearMonth.month)

--- a/frontend/app/src/main/java/com/voyz/presentation/component/reminder/ReminderCalendarComponent.kt
+++ b/frontend/app/src/main/java/com/voyz/presentation/component/reminder/ReminderCalendarComponent.kt
@@ -25,13 +25,17 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.YearMonth
+import java.time.temporal.ChronoUnit
 import java.time.temporal.TemporalAdjusters
 
 @Composable
@@ -39,19 +43,26 @@ fun ReminderCalendarComponent(
     modifier: Modifier = Modifier,
     viewModel: ReminderCalendarViewModel = viewModel(),
     isWeekly: Boolean = false,
+    calendarHeight: Dp,
     onDateSelected: (LocalDate) -> Unit
 ) {
-    val currentMonth = viewModel.currentMonth
-    val selectedDate = viewModel.selectedDate
+    val currentMonth by viewModel.currentMonth
+    val selectedDate by viewModel.selectedDate.collectAsState()
     var totalDrag by remember { mutableStateOf(0f) }
-    val datesToShow = remember(currentMonth, selectedDate, isWeekly) {
-        if (isWeekly) getDatesOfWeek(selectedDate) else getDatesOfMonth(currentMonth)
+    val monthData by remember(currentMonth, selectedDate, isWeekly) {
+        derivedStateOf {
+            if (isWeekly) ReminderMonthData(getDatesOfWeek(selectedDate), 1)
+            else getDatesOfMonth(currentMonth)
+        }
     }
+
+    val screenHeight = LocalConfiguration.current.screenHeightDp.dp
+
 
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .fillMaxHeight()
+            .height(calendarHeight)
             .background(MaterialTheme.colorScheme.background)
             .pointerInput(Unit) {
                 detectHorizontalDragGestures(
@@ -68,7 +79,7 @@ fun ReminderCalendarComponent(
     ) {
         CalendarHeader(currentMonth = currentMonth)
 
-        Box(modifier = Modifier.fillMaxSize()) {
+        Box(modifier = Modifier) {
             AnimatedContent(
                 targetState = currentMonth,
                 transitionSpec = {
@@ -86,15 +97,23 @@ fun ReminderCalendarComponent(
                 modifier = Modifier.fillMaxSize()
             ) {
                 SimpleCalendarGrid(
-                    dates = datesToShow,
+                    dates = monthData.dates,
+                    numberOfWeeks = monthData.numberOfWeeks,
                     selectedDate = selectedDate,
                     events = viewModel.events,
+                    calendarHeight = calendarHeight,
                     onDateClick = { date ->
-                        if (date == selectedDate) viewModel.clearSelection() else {
-                            viewModel.selectDate(date)
-                            onDateSelected(date)
+                        // 항상 클릭한 날짜 선택
+                        val clickedMonth = YearMonth.from(date)
+                        if (clickedMonth != currentMonth) {
+                            viewModel.goToMonth(clickedMonth)
                         }
-                    }
+                        viewModel.selectDate(date)
+                        onDateSelected(date)
+
+                    },
+                    isWeekly = isWeekly
+
                 )
             }
         }
@@ -154,18 +173,22 @@ private fun DaysOfWeekHeader() {
 @Composable
 private fun SimpleCalendarGrid(
     dates: List<ReminderCalendarDate>,
+    numberOfWeeks: Int,
     selectedDate: LocalDate?,
     events: Map<LocalDate, List<ReminderCalendarEvent>>,
-    onDateClick: (LocalDate) -> Unit
+    onDateClick: (LocalDate) -> Unit,
+    isWeekly: Boolean,
+    calendarHeight: Dp
 ) {
+    val rawRowHeight = calendarHeight / numberOfWeeks
+    val rowHeight = rawRowHeight * 0.76f
+
     Column(modifier = Modifier.fillMaxWidth()) {
         DaysOfWeekHeader()
         LazyVerticalGrid(
             columns = GridCells.Fixed(7),
             modifier = Modifier
-                .fillMaxWidth()
-                .weight(1f)
-                .padding(horizontal = 8.dp),
+                .fillMaxWidth(),
             userScrollEnabled = false
         ) {
             items(dates) { calendarDate ->
@@ -175,11 +198,11 @@ private fun SimpleCalendarGrid(
                     isSelected = selectedDate == calendarDate.date,
                     events = events[calendarDate.date] ?: emptyList(),
                     onClick = {
-                        if (calendarDate.isCurrentMonth) onDateClick(calendarDate.date)
+                        onDateClick(calendarDate.date)
                     },
                     modifier = Modifier
                         .fillMaxWidth()
-                        .aspectRatio(1f)
+                        .height(rowHeight)
                 )
             }
         }
@@ -199,7 +222,7 @@ private fun CalendarDayCell(
     val isCheckedExist = events.any { it.isChecked }
     Column(
         modifier = modifier
-            .clickable(enabled = isCurrentMonth) { onClick() }
+            .clickable { onClick() }
             .padding(4.dp),
         verticalArrangement = Arrangement.Top,
         horizontalAlignment = Alignment.CenterHorizontally
@@ -272,16 +295,33 @@ fun getDatesOfWeek(selectedDate: LocalDate?): List<ReminderCalendarDate> {
         ReminderCalendarDate(date, true)
     }
 }
+data class ReminderMonthData(
+    val dates: List<ReminderCalendarDate>,
+    val numberOfWeeks: Int
+)
 
-fun getDatesOfMonth(yearMonth: YearMonth): List<ReminderCalendarDate> {
-    val firstOfMonth = yearMonth.atDay(1)
-    val firstDayOfWeek = firstOfMonth.dayOfWeek.value % 7
-    val startDate = firstOfMonth.minusDays(firstDayOfWeek.toLong())
-    val totalDays = 42
-    return (0 until totalDays).map { offset ->
-        val date = startDate.plusDays(offset.toLong())
-        ReminderCalendarDate(date = date, isCurrentMonth = date.month == yearMonth.month)
+fun getDatesOfMonth(yearMonth: YearMonth): ReminderMonthData {
+    val firstDayOfMonth = yearMonth.atDay(1)
+    val lastDayOfMonth = yearMonth.atEndOfMonth()
+    val start = firstDayOfMonth.with(TemporalAdjusters.previousOrSame(DayOfWeek.SUNDAY))
+    val end = lastDayOfMonth.with(TemporalAdjusters.nextOrSame(DayOfWeek.SATURDAY))
+
+    var allDates = (0..ChronoUnit.DAYS.between(start, end)).map {
+        start.plusDays(it)
     }
+
+    if (allDates.size < 35) {
+        val needed = 35 - allDates.size
+        allDates = allDates + List(needed) { i -> end.plusDays((i + 1).toLong()) }
+    }
+
+    val finalDates = allDates.take(42)
+    val numberOfWeeks = (finalDates.size + 6) / 7
+
+    return ReminderMonthData(
+        dates = finalDates.map { date -> ReminderCalendarDate(date, date.month == yearMonth.month) },
+        numberOfWeeks = numberOfWeeks
+    )
 }
 
 data class ReminderCalendarDate(val date: LocalDate, val isCurrentMonth: Boolean)
@@ -289,5 +329,8 @@ data class ReminderCalendarDate(val date: LocalDate, val isCurrentMonth: Boolean
 @Composable
 @androidx.compose.ui.tooling.preview.Preview(showBackground = true, widthDp = 400, heightDp = 700)
 fun ReminderCalendarComponentPreview() {
-    ReminderCalendarComponent(onDateSelected = {})
+    ReminderCalendarComponent(
+        calendarHeight = 400.dp, // 💡 프리뷰용 고정값
+        onDateSelected = {}
+    )
 }

--- a/frontend/app/src/main/java/com/voyz/presentation/component/reminder/ReminderCalendarViewModel.kt
+++ b/frontend/app/src/main/java/com/voyz/presentation/component/reminder/ReminderCalendarViewModel.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import java.time.LocalDate
 import java.time.YearMonth
+import androidx.compose.runtime.State
 
 
 class ReminderCalendarViewModel : ViewModel() {
@@ -22,12 +23,13 @@ class ReminderCalendarViewModel : ViewModel() {
                 ReminderCalendarEvent("1", "회의"),
                 ReminderCalendarEvent("2", "회의1"),
                 ReminderCalendarEvent("3", "회의2"),
-                ReminderCalendarEvent("4", "회의3")
+                ReminderCalendarEvent("4", "회의3"),
+                ReminderCalendarEvent("5", "회의4")
             ),
-            LocalDate.now().withDayOfMonth(7) to listOf(ReminderCalendarEvent("5", "약속")),
-            LocalDate.now().withDayOfMonth(14) to listOf(ReminderCalendarEvent("6", "생일")),
-            LocalDate.now().withDayOfMonth(21) to listOf(ReminderCalendarEvent("7", "병원")),
-            LocalDate.now().withDayOfMonth(26) to listOf(ReminderCalendarEvent("8", "여행"))
+            LocalDate.now().withDayOfMonth(7) to listOf(ReminderCalendarEvent("6", "약속")),
+            LocalDate.now().withDayOfMonth(14) to listOf(ReminderCalendarEvent("7", "생일")),
+            LocalDate.now().withDayOfMonth(21) to listOf(ReminderCalendarEvent("8", "병원")),
+            LocalDate.now().withDayOfMonth(26) to listOf(ReminderCalendarEvent("9", "여행"))
         )
     )
         private set
@@ -81,21 +83,23 @@ class ReminderCalendarViewModel : ViewModel() {
         currentMonth = YearMonth.from(today)
     }
 
-    fun updateEventCheckStatus(event: ReminderCalendarEvent, isChecked: Boolean) {
-        val date = events.entries.find { it.value.contains(event) }?.key ?: return
-        val updatedEvents = events[date]?.map {
-            if (it.id == event.id) it.copy(isChecked = isChecked) else it
-        } ?: return
+    private val _reminderEvents = mutableStateOf<Map<LocalDate, List<ReminderCalendarEvent>>>(emptyMap())
+    val reminderEvents: State<Map<LocalDate, List<ReminderCalendarEvent>>> = _reminderEvents
 
-        events = events.toMutableMap().apply {
-            put(date, updatedEvents)
+    fun updateEventCheckStatus(eventId: String, isChecked: Boolean) {
+        events = events.mapValues { (_, eventList) ->
+            eventList.map { event ->
+                if (event.id == eventId) event.copy(isChecked = isChecked) else event
+            }
         }
     }
+
 }
 data class ReminderCalendarEvent(
     val id: String,
     val title: String,
     val description: String? = null,
     val time: String? = null,
-    var isChecked: Boolean = false
+    var isChecked: Boolean = false,
+    val originalIndex: Boolean = false
 )

--- a/frontend/app/src/main/java/com/voyz/presentation/component/reminder/ReminderCalendarViewModel.kt
+++ b/frontend/app/src/main/java/com/voyz/presentation/component/reminder/ReminderCalendarViewModel.kt
@@ -7,14 +7,20 @@ import androidx.lifecycle.ViewModel
 import java.time.LocalDate
 import java.time.YearMonth
 import androidx.compose.runtime.State
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 
 class ReminderCalendarViewModel : ViewModel() {
 
-    var selectedDate by mutableStateOf(LocalDate.now())
+    private val _selectedDate = MutableStateFlow(LocalDate.now())
+    val selectedDate: StateFlow<LocalDate> = _selectedDate.asStateFlow()
 
-    var currentMonth by mutableStateOf(YearMonth.now())
-        private set
+
+    private val _currentMonth = mutableStateOf(YearMonth.now())
+    val currentMonth: State<YearMonth> get() = _currentMonth
+
 
     var events by mutableStateOf<Map<LocalDate, List<ReminderCalendarEvent>>>(
         // 테스트용 이벤트 데이터
@@ -35,35 +41,35 @@ class ReminderCalendarViewModel : ViewModel() {
         private set
 
     fun selectDate(date: LocalDate) {
-        selectedDate = date
+        _selectedDate.value = date
     }
 
     fun clearSelection() {
-        selectedDate = null
+        _selectedDate.value = LocalDate.now() // 또는 고정값
     }
 
     fun goToNextMonth() {
-        currentMonth = currentMonth.plusMonths(1)
+        _currentMonth.value = _currentMonth.value.plusMonths(1)
     }
 
     fun goToPreviousMonth() {
-        currentMonth = currentMonth.minusMonths(1)
+        _currentMonth.value = _currentMonth.value.minusMonths(1)
     }
 
     fun goToNextMonthWithDirection(): Pair<YearMonth, Boolean> {
-        val newMonth = currentMonth.plusMonths(1)
-        currentMonth = newMonth
+        val newMonth = currentMonth.value.plusMonths(1)
+        _currentMonth.value = newMonth
         return newMonth to true // true = 다음 달로 이동
     }
 
     fun goToPreviousMonthWithDirection(): Pair<YearMonth, Boolean> {
-        val newMonth = currentMonth.minusMonths(1)
-        currentMonth = newMonth
+        val newMonth = currentMonth.value.minusMonths(1)
+        _currentMonth.value = newMonth
         return newMonth to false // false = 이전 달로 이동
     }
 
     fun goToMonth(yearMonth: YearMonth) {
-        currentMonth = yearMonth
+        _currentMonth.value = yearMonth
     }
 
     fun addEvent(date: LocalDate, event: ReminderCalendarEvent) {
@@ -79,8 +85,8 @@ class ReminderCalendarViewModel : ViewModel() {
 
     fun goToToday() {
         val today = LocalDate.now()
-        selectedDate = today
-        currentMonth = YearMonth.from(today)
+        _selectedDate.value = today
+        _currentMonth.value = YearMonth.from(today)
     }
 
     private val _reminderEvents = mutableStateOf<Map<LocalDate, List<ReminderCalendarEvent>>>(emptyMap())

--- a/frontend/app/src/main/java/com/voyz/presentation/component/reminder/ReminderDayInfoBox.kt
+++ b/frontend/app/src/main/java/com/voyz/presentation/component/reminder/ReminderDayInfoBox.kt
@@ -18,7 +18,8 @@ fun ReminderDayInfoBox(
     selectedDate: LocalDate,
     weatherIcon: String,
     temperature: String,
-    events: List<ReminderCalendarEvent>
+    events: List<ReminderCalendarEvent>,
+    modifier: Modifier = Modifier
 ) {
     val day = selectedDate.dayOfMonth         // 숫자 날짜
     val dayOfWeek =

--- a/frontend/app/src/main/java/com/voyz/presentation/component/reminder/ReminderListBox.kt
+++ b/frontend/app/src/main/java/com/voyz/presentation/component/reminder/ReminderListBox.kt
@@ -1,5 +1,8 @@
 package com.voyz.presentation.component.reminder
 
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -16,12 +19,16 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.Dp
@@ -32,6 +39,9 @@ import com.voyz.ui.theme.Gray900
 import java.time.LocalDate
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.voyz.presentation.component.reminder.ReminderCalendarEvent
+import kotlinx.coroutines.delay
+import androidx.compose.runtime.key
+import androidx.compose.runtime.setValue
 
 
 @Composable
@@ -41,11 +51,21 @@ fun ReminderListBox(
     viewModel: ReminderCalendarViewModel = viewModel(),
     onEventCheckChange: (ReminderCalendarEvent, Boolean) -> Unit
 ) {
+    val orderMap = remember(events) {
+        events.mapIndexed { index, event -> event.id to index }.toMap()
+    }
+    // ✅ 정렬 로직
+    val sortedEvents = events.sortedWith(
+        compareBy<ReminderCalendarEvent> { it.isChecked }
+            .thenBy { if (it.isChecked) Int.MAX_VALUE else orderMap[it.id] ?: 0 }
+    )
+
+
     if (events.isEmpty()) {
         Box(
             modifier = Modifier
-                .fillMaxSize()
-                .padding(bottom = 60.dp),
+                .fillMaxSize(),
+
             contentAlignment = Alignment.Center
         ) {
             Text(
@@ -63,80 +83,26 @@ fun ReminderListBox(
             verticalArrangement = Arrangement.spacedBy(0.dp),
             horizontalAlignment = Alignment.Start
         ) {
-            val sortedEvents = events.sortedWith(
-                compareBy<ReminderCalendarEvent> { it.isChecked }.thenBy { it.id }
-            )
 
-            sortedEvents.forEachIndexed { index, event ->
-                ReminderItemCard(
-                    title = event.title,
-                    isChecked = event.isChecked,
-                    onCheckChange = { checked ->
-                        viewModel.updateEventCheckStatus(event, checked)
-                        onEventCheckChange(event, checked)
-                    }
-                )
+            sortedEvents.forEach { event ->
+                // ✅ 이게 중요: key는 이렇게 wrapping해야 함
+                key(event.id) {
+                    ReminderItemCard(
+                        title = event.title,
+                        isChecked = event.isChecked,
+                        onCheckChange = { newChecked ->
+                            // 바로 UI에 반영하지 않음
+                        },
+                        onDelayedCheckCommit = { finalChecked ->
+                            viewModel.updateEventCheckStatus(event.id, finalChecked)
+                            onEventCheckChange(event, finalChecked)
+                        }
+                    )
+                }
             }
         }
     }
 }
-        @Composable
-        fun ReminderItemCard(
-            title: String,
-            isChecked: Boolean,
-            onCheckChange: (Boolean) -> Unit,
-            allDay: Boolean = false
-        ) {
-            val backgroundColor = Color(0xFFBBDEFB)
-            val textColor = if (isChecked) Color(0xFF757575) else Gray900
-
-
-            Card(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(vertical = 4.dp),
-                shape = RoundedCornerShape(12.dp),
-                colors = CardDefaults.cardColors(
-                    containerColor = backgroundColor
-                )
-
-            ) {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp, vertical = 16.dp),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    CircleCheckbox(
-                        checked = isChecked,
-                        onCheckChange = onCheckChange,
-                        modifier = Modifier
-                            .size(22.dp)
-                            .align(Alignment.Top) // 텍스트 기준으로 정렬 (중앙 아님)
-                    )
-
-                    Spacer(modifier = Modifier.width(16.dp))
-
-                    Column(
-                        verticalArrangement = Arrangement.spacedBy(2.dp)
-                    ) {
-                        Text(
-                            text = title,
-                            fontSize = 18.sp,
-                            color = textColor,
-                            fontWeight = FontWeight.Bold,
-                            textDecoration = if (isChecked) TextDecoration.LineThrough else TextDecoration.None
-                        )
-                        Text(
-                            text = "하루종일",
-                            fontSize = 13.sp,
-                            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
-                            textDecoration = if (isChecked) TextDecoration.LineThrough else TextDecoration.None
-                        )
-                    }
-                }
-            }
-        }
         @Composable
         fun CircleCheckbox(
             checked: Boolean,
@@ -173,4 +139,81 @@ fun ReminderListBox(
                 }
             }
         }
+        @Composable
+        fun ReminderItemCard(
+            title: String,
+            isChecked: Boolean,
+            onCheckChange: (Boolean) -> Unit,
+            onDelayedCheckCommit: (Boolean) -> Unit,
+            allDay: Boolean = false
+        ) {
+            val backgroundColor = Color(0xFFBBDEFB)
+            var localChecked by remember { mutableStateOf(isChecked) }
+
+            LaunchedEffect(isChecked) {
+                if (localChecked != isChecked) {
+                    localChecked = isChecked
+                }
+            }
+            val textColor = if (localChecked) Color(0xFF757575) else Gray900
+
+            val offsetY by animateDpAsState(
+                targetValue = 0.dp, // 항상 0 (이동 느낌만 살릴 수도 있지만 생략 가능)
+                animationSpec = tween(300)
+            )
+
+            LaunchedEffect(localChecked) {
+                delay(300)
+                onDelayedCheckCommit(localChecked)
+            }
+
+            Card(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 4.dp)
+                     .offset(y = offsetY),
+                shape = RoundedCornerShape(12.dp),
+                colors = CardDefaults.cardColors(containerColor = backgroundColor)
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 16.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    CircleCheckbox(
+                        checked = localChecked,
+                        onCheckChange = {
+                            localChecked = it
+                            onCheckChange(it)
+                        },
+                        modifier = Modifier
+                            .size(22.dp)
+                            .align(Alignment.Top) // 텍스트 기준으로 정렬 (중앙 아님)
+                    )
+
+
+                    Spacer(modifier = Modifier.width(16.dp))
+
+                    Column(
+                        verticalArrangement = Arrangement.spacedBy(2.dp)
+                    ) {
+                        Text(
+                            text = title,
+                            fontSize = 18.sp,
+                            color = textColor,
+                            fontWeight = FontWeight.Bold,
+                            textDecoration = if (localChecked) TextDecoration.LineThrough else TextDecoration.None
+                        )
+                        Text(
+                            text = "하루종일",
+                            fontSize = 13.sp,
+                            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
+                            textDecoration = if (localChecked) TextDecoration.LineThrough else TextDecoration.None
+                        )
+                    }
+                }
+            }
+        }
+
 

--- a/frontend/app/src/main/java/com/voyz/presentation/screen/reminder/ReminderDetailScreen.kt
+++ b/frontend/app/src/main/java/com/voyz/presentation/screen/reminder/ReminderDetailScreen.kt
@@ -75,7 +75,8 @@ fun ReminderDetailScreen(
                 colors = TopAppBarDefaults.topAppBarColors(
                     containerColor = MaterialTheme.colorScheme.surface,
                     titleContentColor = MaterialTheme.colorScheme.onSurface
-                )
+                ),
+                windowInsets = WindowInsets(0)
             )
         },
         bottomBar = {

--- a/frontend/app/src/main/java/com/voyz/presentation/screen/reminder/ReminderScreen.kt
+++ b/frontend/app/src/main/java/com/voyz/presentation/screen/reminder/ReminderScreen.kt
@@ -2,20 +2,30 @@ package com.voyz.presentation.screen.reminder
 
 import android.os.Build
 import androidx.annotation.RequiresApi
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.zIndex
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
@@ -28,14 +38,12 @@ import com.voyz.presentation.component.reminder.ReminderListBox
 import com.voyz.presentation.component.sidebar.SidebarComponent
 import com.voyz.presentation.component.topbar.CommonTopBar
 import java.time.LocalDate
-import androidx.compose.foundation.background
-import androidx.compose.foundation.gestures.detectTapGestures
-import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.zIndex
+import androidx.compose.animation.with
+import androidx.compose.ui.layout.onGloballyPositioned
 
 
 @RequiresApi(Build.VERSION_CODES.O)
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalAnimationApi::class)
 @Composable
 fun ReminderScreen(
     navController: NavController,
@@ -50,6 +58,10 @@ fun ReminderScreen(
     val sidebarWidth = with(density) { 280.dp.toPx() }
     val RemindercalendarViewModel: ReminderCalendarViewModel = viewModel()
     val screenHeight = LocalConfiguration.current.screenHeightDp.dp
+    val minCalendarHeight = 300.dp
+    val maxCalendarHeight = 480.dp
+
+    val calculatedHeight = screenHeight * 0.5f
 
     val selectedDate = RemindercalendarViewModel.selectedDate
     val selectedEvents: List<ReminderCalendarEvent> =
@@ -63,6 +75,21 @@ fun ReminderScreen(
         label = "sidebar_offset"
     )
     var isFabExpanded by remember { mutableStateOf(false) }
+
+    var isWeekly by remember { mutableStateOf(false) }
+
+    val calendarHeight by animateDpAsState(
+        targetValue = if (isWeekly) 220.dp else screenHeight * 0.45f,
+        animationSpec = tween(300),
+        label = "calendar_height"
+    )
+
+    val calendarOffsetRatio = 0.15f
+    val reminderExtraHeightRatio = if (isWeekly) 1f + calendarOffsetRatio else 1f
+
+    val calendarWeight by remember { derivedStateOf { if (isWeekly) 0.28f else 0.5f } }
+    val reminderWeight by remember { derivedStateOf { 1f - calendarWeight } }
+
 
     Box(modifier = Modifier.fillMaxSize()) {
         Scaffold(
@@ -115,25 +142,41 @@ fun ReminderScreen(
                     .fillMaxSize()
                     .padding(innerPadding)
             ) {
-                // 상단 절반: 캘린더
+                // 상단 : 캘린더
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .weight(1f),// 화면의 절반 높이
-
+                        .height(calendarHeight)
                 ) {
-                    ReminderCalendarComponent(
-                        modifier = Modifier.fillMaxSize(),
-                        viewModel = RemindercalendarViewModel,
-                        isWeekly = false,
-                        onDateSelected = { RemindercalendarViewModel.selectDate(it) }
-                    )
+                    AnimatedContent(
+                        targetState = isWeekly,
+                        transitionSpec = {
+                            fadeIn(animationSpec = tween(300)) with fadeOut(
+                                animationSpec = tween(
+                                    300)
+                            )
+                        },
+                        label = "calendar_mode_switch"
+                    ) { weekly ->
+                        ReminderCalendarComponent(
+                            modifier = Modifier.fillMaxSize(),
+                            viewModel = RemindercalendarViewModel,
+                            isWeekly = weekly,
+                            onDateSelected = { RemindercalendarViewModel.selectDate(it) }
+                        )
+                    }
                 }
-
                 Box(// 하단
                     modifier = Modifier
                         .fillMaxWidth()
-                        .weight(1f),
+                        .offset(y = (-24).dp)
+                        .pointerInput(Unit) {
+                            detectVerticalDragGestures { _, dragAmount ->
+                                if (dragAmount < -30) isWeekly = true
+                                else if (dragAmount > 30) isWeekly = false
+                            }
+
+                        },
                     contentAlignment = Alignment.TopStart
                 ) {
                     Column(
@@ -153,8 +196,12 @@ fun ReminderScreen(
                         ReminderListBox(
                             events = selectedEvents,
                             selectedDate = selectedDate ?: LocalDate.now(),
+                            viewModel = RemindercalendarViewModel,
                             onEventCheckChange = { event, isChecked ->
-                                RemindercalendarViewModel.updateEventCheckStatus(event, isChecked)
+                                RemindercalendarViewModel.updateEventCheckStatus(
+                                    event.id,
+                                    isChecked
+                                )
                             }
                         )
                     }
@@ -201,6 +248,7 @@ fun ReminderScreen(
             }
         }
     }
+}
     @RequiresApi(Build.VERSION_CODES.O)
     @Preview(showBackground = true)
     @Composable
@@ -208,4 +256,4 @@ fun ReminderScreen(
         val navController = rememberNavController()
         ReminderScreen(navController = navController)
     }
-}
+


### PR DESCRIPTION
- 화면 하단 리마인더 일정에서 상세페이지 이동 구현
- 캘린더 월별 주 수에맞게 5 or 6주 출력
- 현재 월 외의 '일' 클릭시 클릭한 '일'의 '월' 변경 구현
- 리마인더 일정 좌우 스와이핑으로 일 변경 구현
  - 리마인더 스와이핑으로 월 넘겨갈시 캘린더 같이 월 이동 구현 