### PR TITLE
feat : 날씨 관련 데이터 수집 및 반환 

### DIFF
--- a/backend/src/main/java/com/voiz/controller/CalendarController.java
+++ b/backend/src/main/java/com/voiz/controller/CalendarController.java
@@ -12,6 +12,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.voiz.dto.DaySuggestionDto;
+import com.voiz.dto.ForecastResponseDto;
+import com.voiz.dto.WeatherDto;
 import com.voiz.service.CalendarService;
 import com.voiz.vo.Marketing;
 import com.voiz.vo.SpecialDaySuggest;
@@ -76,5 +78,16 @@ public class CalendarController {
 		return ResponseEntity.ok(daySuggestionList);
 	}
 	
+
+
+	@GetMapping("/weather")
+    @Operation(summary = "현재 월 기준 날씨 정보 조회", description = "사용자의 가게 위치를 기반으로 현재 월의 날씨 예보를 조회합니다.")
+    public ResponseEntity<List<ForecastResponseDto<WeatherDto>>> getWeatherForCalendar(
+            @RequestParam("user_id") String userId) {
+
+        // 서비스의 메서드를 호출하고 그 결과를 그대로 반환합니다.
+        List<ForecastResponseDto<WeatherDto>> weatherList = calendarService.getWeatherForCalendar(userId);
+        return ResponseEntity.ok(weatherList);
+    }
 	
 }

--- a/backend/src/main/java/com/voiz/controller/WeatherDataController.java
+++ b/backend/src/main/java/com/voiz/controller/WeatherDataController.java
@@ -1,0 +1,68 @@
+// backend/src/main/java/com/voiz/controller/WeatherDataController.java
+
+package com.voiz.controller;
+
+import java.time.LocalDate;
+
+// import java.time.LocalDate; // 더 이상 필요 없으므로 삭제 가능
+import org.springframework.beans.factory.annotation.Autowired; // Autowired 추가
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.voiz.dto.CurrentWeatherDto;
+import com.voiz.dto.ForecastResponseDto;
+import com.voiz.dto.WeatherDto;
+import com.voiz.dto.WeatherResponseDto;
+import com.voiz.service.WeatherService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+
+@RestController
+@RequestMapping("/api/weather")
+@Tag(name = "data-collect", description = "데이터 수집 API")
+public class WeatherDataController {
+
+    @Autowired // WeatherService를 스프링 컨테이너가 자동으로 주입.
+    private WeatherService weatherService;
+
+    @PostMapping("/weather-data")
+    @Operation(summary = "날씨 데이터 수집", description = "기상청 API를 이용하여 특정 동네의 날씨 예보 데이터를 수집하고 DB에 저장합니다.")
+    
+    public ResponseEntity<Void> collectWeather(@RequestParam String address) {
+        // 주소를 GeoConverter를 통해 위경도와 '동' 이름으로 변환.
+        // WeatherService의 weatherData 메서드를 호출하여 데이터를 수집하고 저장.
+        boolean success = weatherService.weatherData(address);
+        if (success) {
+            return ResponseEntity.ok().build();
+        } else {
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+
+
+    @GetMapping("/current")
+    public ResponseEntity<ForecastResponseDto<CurrentWeatherDto>> getCurrentWeather(@RequestParam("user_id") String userId) {
+        ForecastResponseDto<CurrentWeatherDto> weatherResponse = weatherService.getCurrentWeather(userId);
+        return ResponseEntity.ok(weatherResponse);
+    }
+
+
+
+    @GetMapping("/forecast")
+    @Operation(summary = "일일 예보 정보 조회", description = "사용자의 가게 위치와 특정 날짜(yyyy-MM-dd)를 기준으로 일일 예보를 조회합니다.")
+    public ResponseEntity<ForecastResponseDto<WeatherDto>> getDailyForecast(
+            @RequestParam("user_id") String userId,
+            @RequestParam("date") String dateString) {
+
+        LocalDate date = LocalDate.parse(dateString); // "yyyy-MM-dd" 형식의 문자열을 날짜 객체로 변환
+        ForecastResponseDto<WeatherDto> dailyForecast = weatherService.getDailyForecast(userId, date);
+        return ResponseEntity.ok(dailyForecast);
+    }
+
+}

--- a/backend/src/main/java/com/voiz/dto/CurrentWeatherDto.java
+++ b/backend/src/main/java/com/voiz/dto/CurrentWeatherDto.java
@@ -1,0 +1,16 @@
+package com.voiz.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CurrentWeatherDto {
+    private Double temp; // 현재 기온
+    private Integer sky;  // 하늘 상태 (추가정보 : 1:맑음, 3:구름많음, 4:흐림)
+    private Integer pty;  // 강수 형태 (추가정보 : 0:없음, 1:비, 2:비/눈, 3:눈, 4:소나기)
+    private Integer reh;  // 습도 (%)
+    
+}

--- a/backend/src/main/java/com/voiz/dto/ForecastResponseDto.java
+++ b/backend/src/main/java/com/voiz/dto/ForecastResponseDto.java
@@ -1,0 +1,15 @@
+package com.voiz.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ForecastResponseDto<T> {
+
+    private String description;
+    
+    private T details;
+}

--- a/backend/src/main/java/com/voiz/dto/WeatherDto.java
+++ b/backend/src/main/java/com/voiz/dto/WeatherDto.java
@@ -1,0 +1,21 @@
+package com.voiz.dto;
+
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class WeatherDto {
+    private LocalDate forecastDate; // DB 컬럼명과 통일
+    private Double tmx;             // 일 최고기온 
+    private Double tmn;             // 일 최저기온 
+    private Integer reh;            // 습도 
+    private Integer pop;            // 강수확률 
+    private Integer sky;            // 하늘상태
+    private Integer pty;            // 강수형태
+
+    // tmx, tmn이 null일 경우에는 temp에서 최대, 최소값을 서비스단에서 받아옴
+}

--- a/backend/src/main/java/com/voiz/dto/WeatherResponseDto.java
+++ b/backend/src/main/java/com/voiz/dto/WeatherResponseDto.java
@@ -1,0 +1,14 @@
+package com.voiz.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class WeatherResponseDto {
+    
+    private String description;
+    private CurrentWeatherDto details;
+}

--- a/backend/src/main/java/com/voiz/mapper/WeatherRepository.java
+++ b/backend/src/main/java/com/voiz/mapper/WeatherRepository.java
@@ -1,0 +1,30 @@
+package com.voiz.mapper;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import com.voiz.vo.Weather;
+
+
+
+
+
+@Repository
+public interface WeatherRepository extends JpaRepository<Weather, Long> {
+
+    
+    @Query(value = "SELECT * FROM VOYZ_WEATHER w WHERE w.DONG_NAME = :dongName AND w.FORECAST_DATE BETWEEN :from AND :to",
+           nativeQuery = true)
+    List<Weather> findWeatherByDongNameAndDateRange(
+        @Param("dongName") String dongName,
+        @Param("from") LocalDate from,
+        @Param("to") LocalDate to
+    );
+
+    
+}

--- a/backend/src/main/java/com/voiz/service/CalendarService.java
+++ b/backend/src/main/java/com/voiz/service/CalendarService.java
@@ -2,21 +2,32 @@ package com.voiz.service;
 
 import java.time.LocalDate;
 import java.time.YearMonth;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import com.voiz.dto.DaySuggestionDto;
+import com.voiz.dto.ForecastResponseDto;
 import com.voiz.dto.ReminderDto;
+import com.voiz.dto.WeatherDto;
 import com.voiz.mapper.CalendarRepository;
 import com.voiz.mapper.MarketingRepository;
 import com.voiz.mapper.ReminderRepository;
 import com.voiz.mapper.SpecialDayRepository;
 import com.voiz.mapper.SpecialDaySuggestRepository;
+import com.voiz.mapper.UsersRepository;
+import com.voiz.mapper.WeatherRepository;
+import com.voiz.util.GeoConverter;
 import com.voiz.vo.Marketing;
 import com.voiz.vo.SpecialDaySuggest;
+import com.voiz.vo.Users;
+import com.voiz.vo.Weather;
 
 @Service
 public class CalendarService {
@@ -35,7 +46,16 @@ public class CalendarService {
 	
 	@Autowired
 	private CalendarRepository calendarRepository;
+
+	@Autowired
+	private UsersRepository usersRepository;
+
+	@Autowired
+	private GeoConverter geoConverter;
 	
+	@Autowired
+	private WeatherRepository weatherRepository;
+
 	public Marketing getMarketing(int marketingIdx) {
 		Optional<Marketing> marketing = marketingRepository.findByMarketingIdx(marketingIdx);
 		if(marketing.isPresent()) {
@@ -127,4 +147,95 @@ public class CalendarService {
 	    List<DaySuggestionDto> daySuggestionList = specialDayRepository.findSpecialDaysWithSuggestion(userId, calendarIdx, from, to);
 		return daySuggestionList;
 	}
+
+
+
+	 public List<ForecastResponseDto<WeatherDto>> getWeatherForCalendar(String userId) {
+        
+        Users user = usersRepository.findByUserId(userId)
+                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다: " + userId));
+
+        String storeAddress = user.getStoreAddress();
+        if (storeAddress == null || storeAddress.isBlank()) {
+            return Collections.emptyList();
+        }
+
+        String dongName = geoConverter.convertAddressToCoordinates(storeAddress)
+                .map(geoData -> geoData.dongName())
+                .orElseThrow(() -> new RuntimeException("주소에서 '동' 정보를 추출할 수 없습니다: " + storeAddress));
+        
+        LocalDate now = LocalDate.now();
+        YearMonth ym = YearMonth.of(now.getYear(), now.getMonthValue());
+        LocalDate from = ym.minusMonths(1).atDay(1);
+        LocalDate to = ym.plusMonths(1).atEndOfMonth();
+
+        List<Weather> rawWeatherList = weatherRepository.findWeatherByDongNameAndDateRange(dongName, from, to);
+
+        return rawWeatherList.stream()
+            .collect(Collectors.groupingBy(Weather::getForecastDate))
+            .values().stream()
+            .map(dailyWeather -> {
+                if (dailyWeather.isEmpty()) return null;
+
+                // 1. 상세 데이터를 담은 WeatherDto 생성 (헬퍼 메서드 호출)
+                WeatherDto detailsDto = createDailyWeatherDto(dailyWeather);
+
+                // 2. 상세 데이터를 기반으로 자연어 문장 생성 (헬퍼 메서드 호출)
+                String description = generateCalendarDescription(detailsDto);
+
+                // 3. 문장과 상세 데이터를 최종 DTO(ForecastResponseDto)에 담아 반환
+                return new ForecastResponseDto<>(description, detailsDto);
+            })
+            .filter(Objects::nonNull)
+            .sorted(Comparator.comparing(dto -> dto.getDetails().getForecastDate()))
+            .collect(Collectors.toList());
+    }
+    
+    /**
+     * 하루치 날씨 리스트를 받아 대표 DTO를 생성하는 헬퍼 메서드
+     */
+    private WeatherDto createDailyWeatherDto(List<Weather> dailyWeather) {
+        LocalDate date = dailyWeather.get(0).getForecastDate();
+        Double tmx = dailyWeather.stream().map(Weather::getTmx).filter(Objects::nonNull).findFirst().orElseGet(() -> dailyWeather.stream().mapToDouble(Weather::getTemp).max().orElse(0.0));
+        Double tmn = dailyWeather.stream().map(Weather::getTmn).filter(Objects::nonNull).findFirst().orElseGet(() -> dailyWeather.stream().mapToDouble(Weather::getTemp).min().orElse(0.0));
+        Integer reh = (int) dailyWeather.stream().mapToInt(Weather::getReh).average().orElse(0);
+        Integer pop = dailyWeather.stream().mapToInt(Weather::getPop).max().orElse(0);
+        
+        Weather representativeWeather = dailyWeather.stream().filter(w -> "1200".equals(w.getHour())).findFirst().orElse(dailyWeather.get(0));
+        
+        return new WeatherDto(date, tmx, tmn, reh, pop, representativeWeather.getSky(), representativeWeather.getPty());
+    }
+
+    /**
+     * 캘린더에 표시될 자연어 예보 문장을 생성합니다.
+     */
+    private String generateCalendarDescription(WeatherDto forecast) {
+        String skyState;
+        switch (forecast.getSky()) {
+            case 1: skyState = "맑음"; break;
+            case 3: skyState = "구름많음"; break;
+            case 4: skyState = "흐림"; break;
+            default: skyState = "정보없음"; break;
+        }
+
+        if (forecast.getPty() > 0) {
+            switch (forecast.getPty()) {
+                case 1: skyState = "비"; break;
+                case 2: skyState = "비/눈"; break;
+                case 3: skyState = "눈"; break;
+                case 4: skyState = "소나기"; break;
+            }
+        }
+
+        return String.format(
+            "%d월 %d일: 최고 %.0f°, 최저 %.0f°, %s",
+            forecast.getForecastDate().getMonthValue(),
+            forecast.getForecastDate().getDayOfMonth(),
+            forecast.getTmx(),
+            forecast.getTmn(),
+            skyState
+        );
+    }
+
+
 }

--- a/backend/src/main/java/com/voiz/service/WeatherService.java
+++ b/backend/src/main/java/com/voiz/service/WeatherService.java
@@ -1,0 +1,213 @@
+package com.voiz.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.voiz.dto.CurrentWeatherDto;
+import com.voiz.dto.ForecastResponseDto;
+import com.voiz.dto.WeatherDto;
+import com.voiz.dto.WeatherResponseDto;
+import com.voiz.mapper.WeatherRepository;
+import com.voiz.util.GeoConverter; // 연결될 유틸리티
+import com.voiz.util.WeatherApi;   // 연결될 유틸리티
+import com.voiz.vo.Users;
+import com.voiz.vo.Weather;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+import com.voiz.dto.CurrentWeatherDto; 
+import com.voiz.mapper.UsersRepository; 
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+
+@Service
+public class WeatherService {
+
+    
+    @Autowired private WeatherRepository weatherRepository; // DB 
+    @Autowired private WeatherApi weatherApi;               // 기상청 API 기능
+    @Autowired private GeoConverter geoConverter;           // 좌표 변환 기능
+    @Autowired private UsersRepository usersRepository;
+    
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Transactional
+    public boolean weatherData(String address) {
+        try {
+            // 주소를 좌표로 변환 
+            GeoConverter.GeoData geoData = geoConverter.convertAddressToCoordinates(address)
+                    .orElseThrow(() -> new IllegalArgumentException("주소 변환 실패: " + address));
+
+            // 좌표를 기상청 격자로 변환 (GeoConverter가 구현)
+            GeoConverter.GridData gridData = geoConverter.convertLatLonToGrid(geoData.lat(), geoData.lon());
+
+            // 격자 좌표로 날씨 API 호출 (WeatherApi가 구현)
+            String weatherJson = weatherApi.getWeatherData(String.valueOf(gridData.nx()), String.valueOf(gridData.ny()))
+                    .orElseThrow(() -> new RuntimeException("날씨 정보 조회 실패."));
+
+            // 받아온 데이터를 파싱하고 DB에 저장할 객체로 변환
+            List<Weather> weatherList = parseAndPrepareData(weatherJson, geoData.dongName());
+
+            // 최종 데이터를 DB에 저장 (WeatherRepository가 구현)
+            weatherRepository.saveAll(weatherList);
+            return true;
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            return false;
+        }
+    }
+
+    /**
+     * 기상청에서 받은 JSON 데이터를 파싱 및 Weather 객체 리스트로 변환.
+     */
+    private List<Weather> parseAndPrepareData(String json, String dongName) throws Exception {
+        Map<String, Map<String, Map<String, String>>> forecasts = new LinkedHashMap<>();
+        JsonNode items = objectMapper.readTree(json).path("response").path("body").path("items").path("item");
+
+        if (items.isArray()) {
+            for (JsonNode item : items) {
+                forecasts.computeIfAbsent(item.get("fcstDate").asText(), k -> new LinkedHashMap<>())
+                         .computeIfAbsent(item.get("fcstTime").asText(), k -> new LinkedHashMap<>())
+                         .put(item.get("category").asText(), item.get("fcstValue").asText());
+            }
+        }
+
+        List<Weather> weatherEntities = new ArrayList<>();
+        DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+        for (var dateEntry : forecasts.entrySet()) {
+            String date = dateEntry.getKey();
+            var times = dateEntry.getValue();
+            String dailyTmx = times.values().stream().filter(v -> v.containsKey("TMX")).map(v -> v.get("TMX")).findFirst().orElse(null);
+            String dailyTmn = times.values().stream().filter(v -> v.containsKey("TMN")).map(v -> v.get("TMN")).findFirst().orElse(null);
+
+            for (var timeEntry : times.entrySet()) {
+                if (!timeEntry.getValue().containsKey("TMP")) continue; // 기온(TMP) 없으면 스킵
+
+                Weather weather = new Weather();
+                weather.setDongName(dongName);
+                weather.setForecastDate(LocalDate.parse(date, dateFormatter));
+                weather.setHour(timeEntry.getKey());
+                weather.setTemp(Double.parseDouble(timeEntry.getValue().get("TMP")));
+                weather.setTmx(dailyTmx != null ? Double.parseDouble(dailyTmx) : null);
+                weather.setTmn(dailyTmn != null ? Double.parseDouble(dailyTmn) : null);
+                weather.setSky(Integer.parseInt(timeEntry.getValue().getOrDefault("SKY", "0")));
+                weather.setPty(Integer.parseInt(timeEntry.getValue().getOrDefault("PTY", "0")));
+                weather.setPop(Integer.parseInt(timeEntry.getValue().getOrDefault("POP", "0")));
+                weather.setReh(Integer.parseInt(timeEntry.getValue().getOrDefault("REH", "0")));
+                weather.setWs(Double.parseDouble(timeEntry.getValue().getOrDefault("WSD", "0.0")));
+                weatherEntities.add(weather);
+            }
+        }
+        return weatherEntities;
+
+
+
+        // 현재 날씨 정보 조회 
+        
+
+
+    }
+
+
+
+     @Transactional(readOnly = true)
+    public ForecastResponseDto<CurrentWeatherDto> getCurrentWeather(String userId) {
+        Users user = usersRepository.findByUserId(userId).orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다: " + userId));
+        String storeAddress = user.getStoreAddress();
+        if (storeAddress == null || storeAddress.isBlank()) { throw new RuntimeException("가게 주소가 등록되지 않은 사용자입니다."); }
+        String dongName = geoConverter.convertAddressToCoordinates(storeAddress).map(GeoConverter.GeoData::dongName).orElseThrow(() -> new RuntimeException("주소에서 '동' 정보를 추출할 수 없습니다."));
+
+        LocalDate today = LocalDate.now();
+        List<Weather> todayWeatherList = weatherRepository.findWeatherByDongNameAndDateRange(dongName, today, today);
+        if (todayWeatherList.isEmpty()) { throw new RuntimeException("오늘의 날씨 정보가 DB에 없습니다."); }
+
+        LocalDateTime now = LocalDateTime.now();
+        String currentHourStr = now.format(DateTimeFormatter.ofPattern("HH00"));
+        Weather currentWeather = todayWeatherList.stream()
+                .filter(w -> Integer.parseInt(w.getHour()) <= Integer.parseInt(currentHourStr))
+                .max(Comparator.comparing(Weather::getHour))
+                .orElseThrow(() -> new RuntimeException("현재 시간의 날씨 정보를 찾을 수 없습니다."));
+
+        CurrentWeatherDto detailsDto = new CurrentWeatherDto(currentWeather.getTemp(), currentWeather.getSky(), currentWeather.getPty(), currentWeather.getReh());
+        String description = generateCurrentWeatherDescription(todayWeatherList, detailsDto);
+        return new ForecastResponseDto<>(description, detailsDto);
+    }
+
+    /**
+     * [미래 예보 조회 기능] 특정 사용자의 '지정된 날짜'에 대한 일일 예보를 조회합니다.
+     */
+    @Transactional(readOnly = true)
+    public ForecastResponseDto<WeatherDto> getDailyForecast(String userId, LocalDate date) {
+        Users user = usersRepository.findByUserId(userId).orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다: " + userId));
+        String storeAddress = user.getStoreAddress();
+        if (storeAddress == null || storeAddress.isBlank()) { throw new RuntimeException("가게 주소가 등록되지 않은 사용자입니다."); }
+        String dongName = geoConverter.convertAddressToCoordinates(storeAddress).map(GeoConverter.GeoData::dongName).orElseThrow(() -> new RuntimeException("주소에서 '동' 정보를 추출할 수 없습니다."));
+
+        List<Weather> dailyWeatherList = weatherRepository.findWeatherByDongNameAndDateRange(dongName, date, date);
+        if (dailyWeatherList.isEmpty()) { throw new RuntimeException(date + "의 날씨 정보가 DB에 없습니다."); }
+
+        WeatherDto detailsDto = createDailyWeatherDto(dailyWeatherList);
+        String description = generateForecastDescription(detailsDto);
+        return new ForecastResponseDto<>(description, detailsDto);
+    }
+
+    // --- Private Helper Methods ---
+
+    private String generateCurrentWeatherDescription(List<Weather> todayWeatherList, CurrentWeatherDto currentWeather) {
+        DoubleSummaryStatistics stats = todayWeatherList.stream().mapToDouble(Weather::getTemp).summaryStatistics();
+        String skyState;
+        switch (currentWeather.getSky()) {
+            case 1: skyState = "맑음"; break;
+            case 3: skyState = "구름많음"; break;
+            case 4: skyState = "흐림"; break;
+            default: skyState = "알 수 없음"; break;
+        }
+        String ptyState;
+        switch (currentWeather.getPty()) {
+            case 1: ptyState = ", 비가 와요."; break;
+            case 2: ptyState = ", 비나 눈이 와요."; break;
+            case 3: ptyState = ", 눈이 와요."; break;
+            case 4: ptyState = ", 소나기가 와요."; break;
+            default: ptyState = "입니다."; break;
+        }
+        return String.format("오늘 최고기온은 %.0f도, 최저기온은 %.0f도이며, 현재 날씨는 '%s'%s", stats.getMax(), stats.getMin(), skyState, ptyState);
+    }
+
+    private WeatherDto createDailyWeatherDto(List<Weather> dailyWeather) {
+        LocalDate date = dailyWeather.get(0).getForecastDate();
+        Double tmx = dailyWeather.stream().map(Weather::getTmx).filter(Objects::nonNull).findFirst().orElseGet(() -> dailyWeather.stream().mapToDouble(Weather::getTemp).max().orElse(0.0));
+        Double tmn = dailyWeather.stream().map(Weather::getTmn).filter(Objects::nonNull).findFirst().orElseGet(() -> dailyWeather.stream().mapToDouble(Weather::getTemp).min().orElse(0.0));
+        Integer reh = (int) dailyWeather.stream().mapToInt(Weather::getReh).average().orElse(0);
+        Integer pop = dailyWeather.stream().mapToInt(Weather::getPop).max().orElse(0);
+        Weather representativeWeather = dailyWeather.stream().filter(w -> "1200".equals(w.getHour())).findFirst().orElse(dailyWeather.get(0));
+        return new WeatherDto(date, tmx, tmn, reh, pop, representativeWeather.getSky(), representativeWeather.getPty());
+    }
+
+    private String generateForecastDescription(WeatherDto forecast) {
+        String skyState;
+        switch (forecast.getSky()) {
+            case 1: skyState = "맑음"; break;
+            case 3: skyState = "구름많음"; break;
+            case 4: skyState = "흐림"; break;
+            default: skyState = "알 수 없음"; break;
+        }
+        String ptyState = "";
+        if (forecast.getPty() > 0) {
+            switch (forecast.getPty()) {
+                case 1: ptyState = " 비 소식"; break;
+                case 2: ptyState = " 비 또는 눈 소식"; break;
+                case 3: ptyState = " 눈 소식"; break;
+                case 4: ptyState = " 소나기 소식"; break;
+            }
+        }
+        return String.format("%d월 %d일: 최고 %.0f°, 최저 %.0f°, %s", forecast.getForecastDate().getMonthValue(), forecast.getForecastDate().getDayOfMonth(), forecast.getTmx(), forecast.getTmn(), skyState, ptyState);
+    }
+
+}

--- a/backend/src/main/java/com/voiz/util/GeoConverter.java
+++ b/backend/src/main/java/com/voiz/util/GeoConverter.java
@@ -1,0 +1,76 @@
+// backend/src/main/java/com/voiz/util/GeoConverter.java
+package com.voiz.util;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import java.util.Collections;
+import java.util.Optional;
+
+@Component
+public class GeoConverter {
+
+    private static final String KAKAO_KEY = "289d2b458baae257442cb5ac55c26946";
+    private static final String KAKAO_URL = "https://dapi.kakao.com/v2/local/search/address.json";
+
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    /**
+     * 주소를 위경도와 '동' 이름으로 변환.
+     */
+    public Optional<GeoData> convertAddressToCoordinates(String address) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "KakaoAK " + KAKAO_KEY);
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        String url = KAKAO_URL + "?query=" + address;
+
+        try {
+            ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.GET, entity, String.class);
+            JsonNode doc = objectMapper.readTree(response.getBody()).path("documents").get(0);
+            if (doc == null || doc.isMissingNode()) return Optional.empty();
+
+            double lat = doc.get("y").asDouble();
+            double lon = doc.get("x").asDouble();
+            String dongName = Optional.ofNullable(doc.path("address").path("region_3depth_name").asText(null))
+                                    .orElse(doc.path("road_address").path("region_3depth_name").asText(null));
+
+            return Optional.of(new GeoData(lat, lon, dongName));
+        } catch (Exception e) {
+            e.printStackTrace();
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * 위경도를 기상청 격자 좌표로 변환(이에 특화된 특별한 함수식 사용).
+     */
+    public GridData convertLatLonToGrid(double lat, double lon) {
+        // Python 코드의 latlon_to_xy 함수 로직을 그대로 Java로 구현
+        double RE = 6371.00877, GRID = 5.0, SLAT1 = 30.0, SLAT2 = 60.0, OLON = 126.0, OLAT = 38.0;
+        double XO = 43, YO = 136;
+        double DEGRAD = Math.PI / 180.0;
+        double re = RE / GRID;
+        double slat1 = SLAT1 * DEGRAD, slat2 = SLAT2 * DEGRAD, olon = OLON * DEGRAD, olat = OLAT * DEGRAD;
+
+        double sn = Math.log(Math.cos(slat1) / Math.cos(slat2)) / Math.log(Math.tan(Math.PI * 0.25 + slat2 * 0.5) / Math.tan(Math.PI * 0.25 + slat1 * 0.5));
+        double sf = Math.pow(Math.tan(Math.PI * 0.25 + slat1 * 0.5), sn) * Math.cos(slat1) / sn;
+        double ro = re * sf / Math.pow(Math.tan(Math.PI * 0.25 + olat * 0.5), sn);
+        double ra = re * sf / Math.pow(Math.tan(Math.PI * 0.25 + lat * DEGRAD * 0.5), sn);
+        double theta = lon * DEGRAD - olon;
+        if (theta > Math.PI) theta -= 2.0 * Math.PI;
+        if (theta < -Math.PI) theta += 2.0 * Math.PI;
+        theta *= sn;
+
+        int nx = (int) (ra * Math.sin(theta) + XO + 0.5);
+        int ny = (int) (ro - ra * Math.cos(theta) + YO + 0.5);
+        return new GridData(nx, ny);
+    }
+
+    // 사용할 데이터 전달 record 
+    public record GeoData(double lat, double lon, String dongName) {}
+    public record GridData(int nx, int ny) {}
+}

--- a/backend/src/main/java/com/voiz/util/WeatherApi.java
+++ b/backend/src/main/java/com/voiz/util/WeatherApi.java
@@ -1,0 +1,65 @@
+package com.voiz.util;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Optional;
+
+@Component
+public class WeatherApi {
+
+    public static final String SERVICE_KEY = "Jh+qx6lvBpNoI54Wk48m6uiCTbx/La68eVaDXDTQ+vuKqMqdo24ZhlznKur8ZKvowJ8nTcnlC6mLgQW9GfSHJA==";
+    public static final String BASE_URL = "http://apis.data.go.kr/1360000/VilageFcstInfoService_2.0/getVilageFcst";
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    public Optional<String> getWeatherData(String nx, String ny) {
+        LocalDateTime now = LocalDateTime.now();
+        String baseDate = now.format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+        String baseTime = getBaseTime(now);
+
+        if (baseTime.equals("2300") && now.getHour() < 2) {
+            baseDate = now.minusDays(1).format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+        }
+
+        try {
+            StringBuilder urlBuilder = new StringBuilder(BASE_URL);
+            // URL 인코딩을 사용하여 파라미터를 추가합니다.
+            urlBuilder.append("?" + URLEncoder.encode("serviceKey", StandardCharsets.UTF_8) + "=" + URLEncoder.encode(SERVICE_KEY, StandardCharsets.UTF_8));
+            urlBuilder.append("&" + URLEncoder.encode("pageNo", StandardCharsets.UTF_8) + "=" + URLEncoder.encode("1", StandardCharsets.UTF_8));
+            urlBuilder.append("&" + URLEncoder.encode("numOfRows", StandardCharsets.UTF_8) + "=" + URLEncoder.encode("1000", StandardCharsets.UTF_8));
+            urlBuilder.append("&" + URLEncoder.encode("dataType", StandardCharsets.UTF_8) + "=" + URLEncoder.encode("JSON", StandardCharsets.UTF_8));
+            urlBuilder.append("&" + URLEncoder.encode("base_date", StandardCharsets.UTF_8) + "=" + URLEncoder.encode(baseDate, StandardCharsets.UTF_8));
+            urlBuilder.append("&" + URLEncoder.encode("base_time", StandardCharsets.UTF_8) + "=" + URLEncoder.encode(baseTime, StandardCharsets.UTF_8));
+            urlBuilder.append("&" + URLEncoder.encode("nx", StandardCharsets.UTF_8) + "=" + URLEncoder.encode(nx, StandardCharsets.UTF_8));
+            urlBuilder.append("&" + URLEncoder.encode("ny", StandardCharsets.UTF_8) + "=" + URLEncoder.encode(ny, StandardCharsets.UTF_8));
+
+            URI uri = new URI(urlBuilder.toString());
+            String response = restTemplate.getForObject(uri, String.class);
+            return Optional.ofNullable(response);
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            return Optional.empty();
+        }
+    }
+
+    private String getBaseTime(LocalDateTime now) {
+        int hour = now.getHour();
+        if (now.getMinute() < 45) {
+            hour = now.minusHours(1).getHour();
+        }
+        if (hour < 2) return "2300";
+        if (hour < 5) return "0200";
+        if (hour < 8) return "0500";
+        if (hour < 11) return "0800";
+        if (hour < 14) return "1100";
+        if (hour < 17) return "1400";
+        if (hour < 20) return "1700";
+        if (hour < 23) return "2000";
+        return "2300";
+    }
+}

--- a/backend/src/main/java/com/voiz/vo/Weather.java
+++ b/backend/src/main/java/com/voiz/vo/Weather.java
@@ -1,0 +1,54 @@
+package com.voiz.vo;
+
+import java.time.LocalDate;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "VOYZ_WEATHER")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Weather {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "weather_seq_generator")
+    @SequenceGenerator(name = "weather_seq_generator", sequenceName = "VOYZ_WEATHER_SEQ", allocationSize = 1)
+    @Column(name = "WEATHER_IDX")
+    private Long weatherIdx;
+
+    @Column(name = "DONG_NAME")
+    private String dongName; // 동네 이름(동 기준)
+
+    @Column(name = "FORECAST_DATE")
+    private LocalDate forecastDate; // 일기 예보 날짜
+
+    @Column(name = "HOUR")
+    private String hour; // 일기예보 시간 
+
+    @Column(name = "TEMP")
+    private Double temp; // 기온
+
+    @Column(name = "TMX")
+    private Double tmx; // 일 최고기온
+
+    @Column(name = "TMN")
+    private Double tmn; // 일 최저기온
+
+    @Column(name = "SKY")
+    private Integer sky; // 하늘상태
+
+    @Column(name = "PTY")
+    private Integer pty; // 강수형태
+
+    @Column(name = "POP")
+    private Integer pop; // 강수확률
+
+    @Column(name = "REH")
+    private Integer reh; // 습도
+
+    @Column(name = "WS")
+    private Double ws; // 풍속
+}


### PR DESCRIPTION
- 사용자가 회원가입하는 즉시 해당 가게의 날씨 정보를 자동으로 수집
- DB의 날씨 데이터를 클라이언트까지 가져오 API는 자연어 문장(description)과 JSON 형식의 상세 데이터(details)를 함께 반환
    - GET /api/weather/current: 현재 날씨 조회 (대시보드용)
    - GET /api/weather/forecast: 미래 특정일 상세 예보 조회 (날짜 클릭 시 팝업용)
    - GET /api/calendars/weather: 월별 예보 전체 조회 (캘린더 로딩용)