### PR TITLE
fix: GitHub Actions npm 캐시 설정 제거

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,8 +17,6 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: '18'
-        cache: 'npm'
-        cache-dependency-path: WEBAPP/package-lock.json
     
     # React 앱 빌드
     - name: Install React dependencies


### PR DESCRIPTION
- cache-dependency-path 오류 해결을 위해 npm 캐시 설정 제거