### PR TITLE
fix: npm ci를 npm install로 변경

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Install React dependencies
       run: |
         cd WEBAPP
-        npm ci
+        npm install
     
     - name: Build React app
       run: |


### PR DESCRIPTION
- package-lock.json 없어서 npm ci 실패하는 문제 해결